### PR TITLE
Updating example and adding  saas auth note

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To quickly get started using the Aquasec provider for Terraform, configure the p
 terraform {
   required_providers {
     aquasec = {
-      version = "0.8.3"
+      version = "0.8.4"
       source  = "aquasecurity/aquasec"
     }
   }
@@ -55,6 +55,8 @@ provider "aquasec" {
 ## Using the Aquasec provider SaaS solution
 
 To quickly get started using the Aquasec SaaS provider for Terraform, configure the provider as shown above. The aqua_url should point to cloud.aquasec.com for the Aqua Customers and the Dev/QA Teams need to provide their Urls respectively.
+
+**_NOTE:_**  SaaS authentication is supported from version 0.8.4+
 
 ## Contributing
 


### PR DESCRIPTION
Updating example for provider config as SaaS authentication is supported from version 0.8.4+

Adding not to re enforce the fact that SaaS authentication is supported from version 0.8.4