### PR TITLE
Fix Enforcer Group import functionality

### DIFF
--- a/aquasec/resource_enforcer_group.go
+++ b/aquasec/resource_enforcer_group.go
@@ -337,8 +337,16 @@ func resourceEnforcerGroupCreate(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceEnforcerGroupRead(d *schema.ResourceData, m interface{}) error {
+	var name string
+
 	ac := m.(*client.Client)
-	name := d.Get("group_id").(string)
+	groupId, ok := d.GetOk("group_id")
+
+	if ok {
+		name = groupId.(string)
+	} else {
+		name = d.Id()
+	}
 
 	r, err := ac.GetEnforcerGroup(name)
 	if err == nil {


### PR DESCRIPTION
Enable Enforcer Group (`aquasec_enforcer_groups` resource) imports by updating the mechanism through which an Enforcer Group's `name` is determined:
- In the context of a "standard" `terraform apply` execution on an **_existing_** `aquasec_enforcer_groups` resource, or during the creation of a **_new_** `aquasec_enforcer_groups` resource, the `d.GetOk("group_id")` method should return the resource ID from the local resource configuration.
- In the context of an `aquasec_enforcer_groups` resource **_import_**, the `d.Id()` method should return the proper `id` string representing the Enforcer Group `name`, which is provided via the `terraform import aquasec_enforcer_groups.<resource_id> "<group_id>"` command (via the passed `group_id` value).

Fix #104