### PR TITLE
Remove unused Enforcer Group fields

### DIFF
--- a/aquasec/data_enforcer_group.go
+++ b/aquasec/data_enforcer_group.go
@@ -47,10 +47,6 @@ func dataSourceEnforcerGroup() *schema.Resource {
 				Type:     schema.TypeBool,
 				Computed: true,
 			},
-			"network_activity_protection": {
-				Type:     schema.TypeBool,
-				Computed: true,
-			},
 			"network_protection": {
 				Type:     schema.TypeBool,
 				Computed: true,
@@ -332,7 +328,6 @@ func dataEnforcerGroupRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("gateway_address", group.GatewayAddress)
 		d.Set("enforce", group.Enforce)
 		d.Set("container_activity_protection", group.ContainerAntivirusProtection)
-		d.Set("network_activity_protection", group.NetworkActivityProtection)
 		d.Set("network_protection", group.NetworkProtection)
 		d.Set("behavioral_engine", group.BehavioralEngine)
 		d.Set("host_behavioral_engine", group.BehavioralEngine)

--- a/aquasec/resource_enforcer_group.go
+++ b/aquasec/resource_enforcer_group.go
@@ -178,10 +178,6 @@ func resourceEnforcerGroup() *schema.Resource {
 				Type:     schema.TypeBool,
 				Optional: true,
 			},
-			"hostname": {
-				Type:     schema.TypeString,
-				Computed: true,
-			},
 			"hosts_count": {
 				Type:     schema.TypeInt,
 				Computed: true,
@@ -238,10 +234,6 @@ func resourceEnforcerGroup() *schema.Resource {
 			"neg_vulns": {
 				Type:     schema.TypeInt,
 				Computed: true,
-			},
-			"network_activity_protection": {
-				Type:     schema.TypeBool,
-				Optional: true,
 			},
 			"network_protection": {
 				Type:     schema.TypeBool,
@@ -351,7 +343,6 @@ func resourceEnforcerGroupRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("gateway_address", r.GatewayAddress)
 		d.Set("enforce", r.Enforce)
 		d.Set("container_activity_protection", r.ContainerAntivirusProtection)
-		d.Set("network_activity_protection", r.NetworkActivityProtection)
 		d.Set("network_protection", r.NetworkProtection)
 		d.Set("behavioral_engine", r.BehavioralEngine)
 		d.Set("host_behavioral_engine", r.BehavioralEngine)

--- a/client/enforcers.go
+++ b/client/enforcers.go
@@ -36,7 +36,6 @@ type EnforcerGroup struct {
 	GatewayAddress                            string               `json:"gateway_address"`
 	Enforce                                   bool                 `json:"enforce"`
 	ContainerActivityProtection               bool                 `json:"container_activity_protection"`
-	NetworkActivityProtection                 bool                 `json:"network_activity_protection"`
 	NetworkProtection                         bool                 `json:"network_protection"`
 	BehavioralEngine                          bool                 `json:"behavioral_engine"`
 	HostBehavioralEngine                      bool                 `json:"host_behavioral_engine"`

--- a/docs/data-sources/enforcer_groups.md
+++ b/docs/data-sources/enforcer_groups.md
@@ -3,7 +3,7 @@
 page_title: "aquasec_enforcer_groups Data Source - terraform-provider-aquasec"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # Data Source `aquasec_enforcer_groups`
@@ -70,7 +70,6 @@ description: |-
 - **micro_enforcer_injection** (Boolean)
 - **micro_enforcer_secrets_name** (String)
 - **neg_vulns** (Number)
-- **network_activity_protection** (Boolean)
 - **network_protection** (Boolean)
 - **orchestrator** (List of Object) (see [below for nested schema](#nestedatt--orchestrator))
 - **pas_deployment_link** (String)

--- a/docs/resources/enforcer_groups.md
+++ b/docs/resources/enforcer_groups.md
@@ -3,7 +3,7 @@
 page_title: "aquasec_enforcer_groups Resource - terraform-provider-aquasec"
 subcategory: ""
 description: |-
-  
+
 ---
 
 # Resource `aquasec_enforcer_groups`
@@ -54,7 +54,6 @@ description: |-
 - **micro_enforcer_image_name** (String)
 - **micro_enforcer_injection** (Boolean)
 - **micro_enforcer_secrets_name** (String)
-- **network_activity_protection** (Boolean)
 - **network_protection** (Boolean)
 - **permission** (String)
 - **risk_explorer_auto_discovery** (Boolean)
@@ -73,7 +72,6 @@ description: |-
 - **gateway_name** (String)
 - **high_vulns** (Number)
 - **host_os** (String)
-- **hostname** (String)
 - **hosts_count** (Number)
 - **install_command** (String)
 - **last_update** (Number)


### PR DESCRIPTION
Remove all references to `NetworkActivityProtection` and `network_activity_protection` from Enforcer Group-related type definitions and functions. Also remove the unnecessary inclusion of `hostname` in the Enforcer Group's `schema.Resource` object.

Fix #105