### PR TITLE
Enable setting Enforcer Group's host_os parameter

### DIFF
--- a/aquasec/resource_enforcer_group.go
+++ b/aquasec/resource_enforcer_group.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aquasecurity/terraform-provider-aquasec/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
 func resourceEnforcerGroup() *schema.Resource {
@@ -167,8 +168,11 @@ func resourceEnforcerGroup() *schema.Resource {
 				Optional: true,
 			},
 			"host_os": {
-				Type:     schema.TypeString,
-				Computed: true,
+				Type:         schema.TypeString,
+				Computed:     true,
+				Optional:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringInSlice([]string{"Linux", "Windows"}, false),
 			},
 			"host_protection": {
 				Type:     schema.TypeBool,


### PR DESCRIPTION
Allow the `host_os` parameter to be set when creating an Enforcer Group, so that `Windows` Enforcer Groups can also be created. Recreate the resource if the `host_os` type is changed. Validate the input, so that only valid inputs are accepted.

Fix #107