### PR TITLE
Fix ability to set Enforcer Group's type

### DIFF
--- a/aquasec/data_enforcer_group.go
+++ b/aquasec/data_enforcer_group.go
@@ -345,7 +345,6 @@ func dataEnforcerGroupRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("token", group.Token)
 		d.Set("command", flattenCommands(group.Command))
 		d.Set("orchestrator", flattenOrchestrators(group.Orchestrator))
-		d.Set("type", group.Type)
 		d.Set("host_os", group.HostOs)
 		d.Set("install_command", group.InstallCommand)
 		d.Set("hosts_count", group.HostsCount)


### PR DESCRIPTION
Fix the ability to set the `type` parameter for an Enforcer Group. This requires adding a code block to the `expandEnforcerGroup` function, which sets `enforcerGroup.Type`.

Since there is a limited set of inputs that the `type` parameter can accept, the input is validated via a `ValidateFunc` function. Also, since the `type` value cannot be changed once it has been set for an Enforcer Group, `ForceNew: true` is used to allow recreation of the Enforcer Group resource if the `type` needs to change (e.g. if the wrong `type` was initially set for a particular `group_id`, and the implementer wants to change it).

Since certain Enforcer Group types require that an explicit `runtime_type` is set (in fact, the only current case is that setting `type="kube_enforcer"` also requires that `runtime_type="docker"` is explicitly set), the ability to specify a `runtime_type` parameter has also been enabled. All Enforcer Group types **_except_** `kube_enforcer` are actually able to accept **_any_** passed `runtime_type` parameter without throwing an error; however, it seems that the `agent` type (the "Aqua Enforcer" Enforcer Group type) is the only Enforcer Group type that actually makes use of alternate `runtime_type` parameter values (meaning, those other than `docker`, e.g. `crio`, `containerd`, and `garden`). Accordingly, since there is a limited set of inputs that the `runtime_type` parameter should accept, the input is validated via a `ValidateFunc` function.

It is possible to enable the ability to explicitly set the parameter `runtime_type`, while also accounting for the fact that it may be omitted from the configuration. Per the `terraform-plugin-sdk` package, it is possible to set both `Computed: true` **_and_** `Optional: true` at the same time (ref: https://github.com/hashicorp/terraform-plugin-sdk/blob/v2.14.0/helper/schema/schema.go#L41-L43). The result is that the `Optional` value will be used (if provided), and if not provided, then a default value will be `Computed`. In this particular case, the Aqua Server does not actually compute a default `runtime_type` value; if it is not set in the resource configuration, the value will generally be an empty string (`""`). However, to account for the fact that the `kube_enforcer` Enforcer Group type **_must always_** have its `runtime_type` set to `docker` (regardless of what may have been explicitly set via the `runtime_type` parameter in the resource configuration), this requirement has been accounted for in the code block that sets the value of `enforcerGroup.Type` (within the `expandEnforcerGroup` function). The reason for doing this is that failing to set `runtime_type=docker` for the `kube_enforcer` Enforcer Group type would otherwise result in an error (and fail to create the resource), but the actual reason for the failure is not present in the provider's error output. The true cause of the failure is only clear when using another tool for troubleshooting, to hit the API directly (e.g. Postman), in which the following error would be shown:
```
"Currently  container runtime is not supported, supported container runtime is only docker for kube enforcer"
```
Codifying `runtime_type=docker` for the `kube_enforcer` Enforcer Group type prevents the possibility of ever encountering this otherwise confusion failure condition.

**_Note:_** there are duplicate occurrences of `d.Set("type", group.Type)` in both `aquasec/data_enforcer_group.go` and `aquasec/resource_enforcer_group.go`, which have accordingly been removed.

Fix #115