### PR TITLE
Fixing kube-enforcer group creation issue:

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ HOSTNAME	 := github.com
 NAMESPACE	 := aquasec
 NAME 		 := aquasec
 BINARY		 := terraform-provider-${NAME}
-VERSION      := 0.8.10
+VERSION      := 0.8.11
 OS_ARCH      := $(shell go env GOOS)_$(shell go env GOARCH)
 
 default: build

--- a/aquasec/resource_enforcer_group.go
+++ b/aquasec/resource_enforcer_group.go
@@ -500,6 +500,16 @@ func expandEnforcerGroup(d *schema.ResourceData) client.EnforcerGroup {
 	enforcerType, ok := d.GetOk("type")
 	if ok {
 		enforcerGroup.Type = enforcerType.(string)
+		if enforcerType != "agent" {
+			enforcerGroup.RuntimeType = "docker"
+		} else {
+			runtimeType, ok := d.GetOk("runtime_type")
+			if ok {
+				enforcerGroup.RuntimeType = runtimeType.(string)
+			} else {
+				enforcerGroup.RuntimeType = "docker"
+			}
+		}
 	}
 
 	admissionControl, ok := d.GetOk("admission_control")
@@ -675,11 +685,6 @@ func expandEnforcerGroup(d *schema.ResourceData) client.EnforcerGroup {
 	riskExplorerAutoDiscovery, ok := d.GetOk("risk_explorer_auto_discovery")
 	if ok {
 		enforcerGroup.RiskExplorerAutoDiscovery = riskExplorerAutoDiscovery.(bool)
-	}
-
-	runtimeType, ok := d.GetOk("runtime_type")
-	if ok {
-		enforcerGroup.RuntimeType = runtimeType.(string)
 	}
 
 	syncHostImages, ok := d.GetOk("sync_host_images")


### PR DESCRIPTION
fixing the following error when creating kube-enforcer group without runtime var.
`Error: {"message":"Currently container runtime is not supported, supported container runtime is only docker for kube enforcer","code":400}
`

Setting runtime type as "docker" when creating enforcer group that not agent type.
Setting runtime type as "docker" as default in agent when user not set it. 

fixes: #124 