### PR TITLE
Adding first_time var to create user function

### DIFF
--- a/aquasec/resource_user.go
+++ b/aquasec/resource_user.go
@@ -106,6 +106,11 @@ func resourceUserCreate(d *schema.ResourceData, m interface{}) error {
 		basicUser.Roles = convertStringArr(roles.([]interface{}))
 	}
 
+	firstTime, ok := d.GetOk("first_time")
+	if ok {
+		basicUser.FirstTime = firstTime.(bool)
+	}
+
 	user := client.FullUser{
 		BasicId:   basicId,
 		BasicUser: basicUser,


### PR DESCRIPTION
fixing: User created using "aquasec_user" resource with "first_time" doesn't have "Password reset" enabled
Fix #128 