### PR TITLE
Removing permission set verification before sending api creation, it …

### DIFF
--- a/client/permission_sets.go
+++ b/client/permission_sets.go
@@ -94,43 +94,6 @@ func Find(slice []string, val string) bool {
 
 // CreatePermissionSet - creates single Aqua PermissionSet Assurance Policy
 func (cli *Client) CreatePermissionsSet(permissionset *PermissionsSet) error {
-	actions_list := []string{
-		"dashboard.read",
-		"risks.vulnerabilities.read",
-		"risks.vulnerabilities.write",
-		"risks.host_images.read",
-		"risks.benchmark.read",
-		"risk_explorer.read",
-		"images.read",
-		"image_profiles.read",
-		"image_assurance.read",
-		"image_assurance.write",
-		"runtime_policies.read",
-		"runtime_policies.write",
-		"functions.read",
-		"gateways.read",
-		"secrets.read",
-		"audits.read",
-		"containers.read",
-		"enforcers.read",
-		"infrastructure.read",
-		"consoles.read",
-		"settings.read",
-		"network_policies.read",
-		"acl_policies.read",
-		"acl_policies.write",
-		"services.read",
-		"integrations.read",
-		"registries_integrations.read",
-		"web_hook.read",
-		"incidents.read"}
-	for _, item := range permissionset.Actions {
-
-		found := Find(actions_list, item)
-		if found != true {
-			return errors.New("Valid values for var: actions_list are ( dashboard.read, risks.vulnerabilities.read, risks.vulnerabilities.write, risks.host_images.read, risks.benchmark.read, risk_explorer.read, images.read, image_profiles.read, image_assurance.read, image_assurance.write, runtime_policies.read, runtime_policies.write, functions.read, gateways.read, secrets.read, audits.read, containers.read, enforcers.read, infrastructure.read, consoles.read, settings.read, network_policies.read, acl_policies.read,acl_policies.write, services.read, integrations.read, registries_integrations.read, web_hook.read, incidents.read )")
-		}
-	}
 	payload, err := json.Marshal(permissionset)
 	if err != nil {
 		return err
@@ -161,43 +124,6 @@ func (cli *Client) CreatePermissionsSet(permissionset *PermissionsSet) error {
 
 // UpdatePermissionSet updates an existing PermissionSet Assurance Policy
 func (cli *Client) UpdatePermissionsSet(permissionset *PermissionsSet) error {
-	actions_list := []string{
-		"dashboard.read",
-		"risks.vulnerabilities.read",
-		"risks.vulnerabilities.write",
-		"risks.host_images.read",
-		"risks.benchmark.read",
-		"risk_explorer.read",
-		"images.read",
-		"image_profiles.read",
-		"image_assurance.read",
-		"image_assurance.write",
-		"runtime_policies.read",
-		"runtime_policies.write",
-		"functions.read",
-		"gateways.read",
-		"secrets.read",
-		"audits.read",
-		"containers.read",
-		"enforcers.read",
-		"infrastructure.read",
-		"consoles.read",
-		"settings.read",
-		"network_policies.read",
-		"acl_policies.read",
-		"acl_policies.write",
-		"services.read",
-		"integrations.read",
-		"registries_integrations.read",
-		"web_hook.read",
-		"incidents.read"}
-	for _, item := range permissionset.Actions {
-
-		found := Find(actions_list, item)
-		if found != true {
-			return errors.New("Valid values for var: actions_list are ( dashboard.read, risks.vulnerabilities.read, risks.vulnerabilities.write, risks.host_images.read, risks.benchmark.read, risk_explorer.read, images.read, image_profiles.read, image_assurance.read, image_assurance.write, runtime_policies.read, runtime_policies.write, functions.read, gateways.read, secrets.read, audits.read, containers.read, enforcers.read, infrastructure.read, consoles.read, settings.read, network_policies.read, acl_policies.read,acl_policies.write, services.read, integrations.read, registries_integrations.read, web_hook.read, incidents.read )")
-		}
-	}
 	payload, err := json.Marshal(permissionset)
 	if err != nil {
 		return err

--- a/docs/resources/enforcer_groups.md
+++ b/docs/resources/enforcer_groups.md
@@ -14,9 +14,58 @@ description: |-
 
 ```terraform
 resource "aquasec_enforcer_groups" "group" {
-    group_id = "IacGroup"
+    group_id = "tf-test-enforcer"
     type = "agent"
+    enforce = true
+    # Host Assurance
+    host_assurance = true
+    # Network Firewall (Host Protection)
+    host_network_protection = true
+    # Runtime Controls
+    host_protection = true
+    # Network Firewall (Container Protection)
+    network_protection = true
+    # Advanced Malware Protection (Container Protection)
+    container_antivirus_protection = true
+    # Runtime Controls
+    container_activity_protection = true
+    # Image Assurance
+    image_assurance = true
+    # Advanced Malware Protection (Host Protection)
+    antivirus_protection = true
+    # Host Images
+    sync_host_images = true
+    # Risk Explorer
+    risk_explorer_auto_discovery = true
     orchestrator {}
+}
+
+resource "aquasec_enforcer_groups" "group-kube_enforcer" {
+    group_id = "tf-test-kube_enforcer"
+    type = "kube_enforcer"
+    enforce = true
+
+    # Enable admission control
+    admission_control = true
+    # Perform admission control if not connected to a gateway
+    block_admission_control = true
+    # Enable workload discovery
+    auto_discovery_enabled = true
+    # Register discovered pod images
+    auto_scan_discovered_images_running_containers = true
+    # Add discovered registries
+    auto_discover_configure_registries = true
+    # Kube-bench image path
+    kube_bench_image_name = "registry.aquasec.com/kube-bench:v0.6.5"
+    # Secret that holds the registry credentials for the Pod Enforcer and kube-bench
+    micro_enforcer_secrets_name = "aqua-registry"
+    # Auto copy these secrets to the Pod Enforcer namespace and container
+    auto_copy_secrets = true
+
+    orchestrator {
+        type = "kubernetes"
+        namespace = "aqua"
+    }
 }
 ```
 

--- a/docs/resources/permissions_sets.md
+++ b/docs/resources/permissions_sets.md
@@ -14,41 +14,101 @@ The `aquasec_permissions_sets` resource manages your Permission Set within Aqua.
 
 ```terraform
 resource "aquasec_permissions_sets" "my_terraform_perm_set" {
-    name = "my_terraform_perm_set"
-    description     = "created from terraform"
-    author    = "system"
-    ui_access = true
-    is_super = false
+        name        = "my_terraform_perm_set"
+    description = "Test Permissions Sets created by Terraform"
+    author      = "system"
+    ui_access   = true
+    is_super    = false
     actions = [
-        "dashboard.read",
-        "risks.vulnerabilities.read",
-        "risks.vulnerabilities.write",
-        "risks.host_images.read",
-        "risks.benchmark.read",
-        "risk_explorer.read",
-        "images.read",
-        "image_profiles.read",
-        "image_assurance.read",
-        "image_assurance.write",
-        "runtime_policies.read",
-        "runtime_policies.write",
-        "functions.read",
-        "gateways.read",
-        "secrets.read",
-        "audits.read",
-        "containers.read",
-        "enforcers.read",
-        "infrastructure.read",
-        "consoles.read",
-        "settings.read",
-        "network_policies.read",
-        "acl_policies.read",
-        "acl_policies.write",
-        "services.read",
-        "integrations.read",
-        "registries_integrations.read",
-        "web_hook.read",
-        "incidents.read"
+        #################
+    # Policies
+    #################
+    # Assurance Policies
+    "acl_policies.read",                # Removed from version 2022.4
+    "acl_policies.write",               # Removed from version 2022.4
+    # Image Profiles
+    "image_profiles.read",
+    "image_profiles.write",             # Only for version 2022.4
+    # Firewall Policies
+    "network_policies.read",
+    "network_policies.write",           # Only for version 2022.4
+    # Runtime Policies
+    "runtime_policies.read",
+    "runtime_policies.write",
+    # Response Policies                 # Only for version 2022.4
+    "response_policies.read",           # Only for version 2022.4
+    "response_policies.write",          # Only for version 2022.4
+    # User Access Control Policies
+    "image_assurance.read",
+    "image_assurance.write",
+
+    #################
+    # Assets
+    #################
+    # Dashboard
+    "dashboard.read",
+    "dashboard.write",                  # Only for version 2022.4
+    # Risk Explorer
+    "risk_explorer.read",
+    # Images
+    "images.read",
+    "images.write",                     # Only for version 2022.4
+    # Host Images
+    "risks.host_images.read",
+    "risks.host_images.write",          # Only for version 2022.4
+    # Functions
+    "functions.read",
+    "functions.write",                  # Only for version 2022.4
+    # Enforcers
+    "enforcers.read",
+    "enforcers.write",                  # Only for version 2022.4
+    # Containers
+    "containers.read",
+    # Services
+    "services.read",
+    "services.write",                   # Only for version 2022.4
+    # Infrastructure
+    "infrastructure.read",
+    "infrastructure.write",             # Only for version 2022.4
+
+    #################
+    # Compliance
+    #################
+    # Vulnerabilities
+    "risks.vulnerabilities.read",
+    "risks.vulnerabilities.write",
+    # CIS Benchmarks
+    "risks.benchmark.read",
+    "risks.benchmark.write",            # Only for version 2022.4
+
+    #################
+    # System
+    #################
+    # Audit Events
+    "audits.read",
+    # Secrets
+    "secrets.read",
+    "secrets.write",                    # Only for version 2022.4
+    # Settings
+    "settings.read",
+    "settings.write",                   # Only for version 2022.4
+    # Integrations
+    "integrations.read",
+    "integrations.write",               # Only for version 2022.4
+    # Image Registry Integrations
+    "registries_integrations.read",
+    "registries_integrations.write",    # Only for version 2022.4
+    # Scanner CLI                       # Only for version 2022.4
+    "scan.read",                        # Only for version 2022.4
+    # Gateways
+    "gateways.read",
+    "gateways.write",                   # Only for version 2022.4
+    # Consoles
+    "consoles.read",
+    # Webhook authorization API
+    "web_hook.read",
+    # Incidents
+    "incidents.read"
     ]
 }
 ```

--- a/examples/resources/aquasec_enforcer_groups/resource.tf
+++ b/examples/resources/aquasec_enforcer_groups/resource.tf
@@ -1,5 +1,54 @@
 resource "aquasec_enforcer_groups" "group" {
-    group_id = "IacGroup"
+    group_id = "tf-test-enforcer"
     type = "agent"
+    enforce = true
+    # Host Assurance
+    host_assurance = true
+    # Network Firewall (Host Protection)
+    host_network_protection = true
+    # Runtime Controls
+    host_protection = true
+    # Network Firewall (Container Protection)
+    network_protection = true
+    # Advanced Malware Protection (Container Protection)
+    container_antivirus_protection = true
+    # Runtime Controls
+    container_activity_protection = true
+    # Image Assurance
+    image_assurance = true
+    # Advanced Malware Protection (Host Protection)
+    antivirus_protection = true
+    # Host Images
+    sync_host_images = true
+    # Risk Explorer
+    risk_explorer_auto_discovery = true
     orchestrator {}
+}
+
+resource "aquasec_enforcer_groups" "group-kube_enforcer" {
+    group_id = "tf-test-kube_enforcer"
+    type = "kube_enforcer"
+    enforce = true
+
+    # Enable admission control
+    admission_control = true
+    # Perform admission control if not connected to a gateway
+    block_admission_control = true
+    # Enable workload discovery
+    auto_discovery_enabled = true
+    # Register discovered pod images
+    auto_scan_discovered_images_running_containers = true
+    # Add discovered registries
+    auto_discover_configure_registries = true
+    # Kube-bench image path
+    kube_bench_image_name = "registry.aquasec.com/kube-bench:v0.6.5"
+    # Secret that holds the registry credentials for the Pod Enforcer and kube-bench
+    micro_enforcer_secrets_name = "aqua-registry"
+    # Auto copy these secrets to the Pod Enforcer namespace and container
+    auto_copy_secrets = true
+
+    orchestrator {
+        type = "kubernetes"
+        namespace = "aqua"
+    }
 }

--- a/examples/resources/aquasec_permissions_sets/resource.tf
+++ b/examples/resources/aquasec_permissions_sets/resource.tf
@@ -1,38 +1,98 @@
 resource "aquasec_permissions_sets" "my_terraform_perm_set" {
-    name = "my_terraform_perm_set"
-    description     = "created from terraform"
-    author    = "system"
-    ui_access = true
-    is_super = false
+        name        = "my_terraform_perm_set"
+    description = "Test Permissions Sets created by Terraform"
+    author      = "system"
+    ui_access   = true
+    is_super    = false
     actions = [
-        "dashboard.read",
-        "risks.vulnerabilities.read",
-        "risks.vulnerabilities.write",
-        "risks.host_images.read",
-        "risks.benchmark.read",
-        "risk_explorer.read",
-        "images.read",
-        "image_profiles.read",
-        "image_assurance.read",
-        "image_assurance.write",
-        "runtime_policies.read",
-        "runtime_policies.write",
-        "functions.read",
-        "gateways.read",
-        "secrets.read",
-        "audits.read",
-        "containers.read",
-        "enforcers.read",
-        "infrastructure.read",
-        "consoles.read",
-        "settings.read",
-        "network_policies.read",
-        "acl_policies.read",
-        "acl_policies.write",
-        "services.read",
-        "integrations.read",
-        "registries_integrations.read",
-        "web_hook.read",
-        "incidents.read"
+        #################
+    # Policies
+    #################
+    # Assurance Policies
+    "acl_policies.read",                # Removed from version 2022.4
+    "acl_policies.write",               # Removed from version 2022.4
+    # Image Profiles
+    "image_profiles.read",
+    "image_profiles.write",             # Only for version 2022.4
+    # Firewall Policies
+    "network_policies.read",
+    "network_policies.write",           # Only for version 2022.4
+    # Runtime Policies
+    "runtime_policies.read",
+    "runtime_policies.write",
+    # Response Policies                 # Only for version 2022.4
+    "response_policies.read",           # Only for version 2022.4
+    "response_policies.write",          # Only for version 2022.4
+    # User Access Control Policies
+    "image_assurance.read",
+    "image_assurance.write",
+
+    #################
+    # Assets
+    #################
+    # Dashboard
+    "dashboard.read",
+    "dashboard.write",                  # Only for version 2022.4
+    # Risk Explorer
+    "risk_explorer.read",
+    # Images
+    "images.read",
+    "images.write",                     # Only for version 2022.4
+    # Host Images
+    "risks.host_images.read",
+    "risks.host_images.write",          # Only for version 2022.4
+    # Functions
+    "functions.read",
+    "functions.write",                  # Only for version 2022.4
+    # Enforcers
+    "enforcers.read",
+    "enforcers.write",                  # Only for version 2022.4
+    # Containers
+    "containers.read",
+    # Services
+    "services.read",
+    "services.write",                   # Only for version 2022.4
+    # Infrastructure
+    "infrastructure.read",
+    "infrastructure.write",             # Only for version 2022.4
+
+    #################
+    # Compliance
+    #################
+    # Vulnerabilities
+    "risks.vulnerabilities.read",
+    "risks.vulnerabilities.write",
+    # CIS Benchmarks
+    "risks.benchmark.read",
+    "risks.benchmark.write",            # Only for version 2022.4
+
+    #################
+    # System
+    #################
+    # Audit Events
+    "audits.read",
+    # Secrets
+    "secrets.read",
+    "secrets.write",                    # Only for version 2022.4
+    # Settings
+    "settings.read",
+    "settings.write",                   # Only for version 2022.4
+    # Integrations
+    "integrations.read",
+    "integrations.write",               # Only for version 2022.4
+    # Image Registry Integrations
+    "registries_integrations.read",
+    "registries_integrations.write",    # Only for version 2022.4
+    # Scanner CLI                       # Only for version 2022.4
+    "scan.read",                        # Only for version 2022.4
+    # Gateways
+    "gateways.read",
+    "gateways.write",                   # Only for version 2022.4
+    # Consoles
+    "consoles.read",
+    # Webhook authorization API
+    "web_hook.read",
+    # Incidents
+    "incidents.read"
     ]
 }


### PR DESCRIPTION
…will move the verification to aqua api.

Updating resource example for permissions_sets and enforcer_groups
Fix: #131 