### PR TITLE
Adding auto_pull_interval to registry resource

### DIFF
--- a/aquasec/data_registry.go
+++ b/aquasec/data_registry.go
@@ -51,6 +51,11 @@ func dataSourceRegistry() *schema.Resource {
 				Description: "The time of day to start pulling new images from the registry, in the format HH:MM (24-hour clock), defaults to 03:00",
 				Computed:    true,
 			},
+			"auto_pull_interval": {
+				Type:        schema.TypeInt,
+				Description: "The interval in days to start pulling new images from the registry, Defaults to 1",
+				Computed:    true,
+			},
 			"scanner_type": {
 				Type:        schema.TypeString,
 				Description: "Scanner type",
@@ -83,6 +88,7 @@ func dataRegistryRead(d *schema.ResourceData, m interface{}) error {
 		d.Set("auto_pull", reg.AutoPull)
 		d.Set("auto_pull_max", reg.AutoPullMax)
 		d.Set("auto_pull_time", reg.AutoPullTime)
+		d.Set("auto_pull_interval", reg.AutoPullInterval)
 		d.Set("scanner_type", reg.ScannerType)
 		d.Set("prefixes", convertStringArr(prefixes))
 		d.SetId(name)

--- a/aquasec/resource_registry.go
+++ b/aquasec/resource_registry.go
@@ -71,6 +71,11 @@ func resourceRegistry() *schema.Resource {
 				Description: "The time of day to start pulling new images from the registry, in the format HH:MM (24-hour clock), defaults to 03:00",
 				Optional:    true,
 			},
+			"auto_pull_interval": {
+				Type:        schema.TypeInt,
+				Description: "The interval in days to start pulling new images from the registry, Defaults to 1",
+				Optional:    true,
+			},
 			"scanner_type": {
 				Type:        schema.TypeString,
 				Description: "The Scanner type",
@@ -105,6 +110,7 @@ func resourceRegistryCreate(d *schema.ResourceData, m interface{}) error {
 		AutoPull:     d.Get("auto_pull").(bool),
 		AutoPullMax:  d.Get("auto_pull_max").(int),
 		AutoPullTime: d.Get("auto_pull_time").(string),
+		AutoPullInterval: d.Get("auto_pull_interval").(int),
 		ScannerType:  scannerType,
 		Prefixes:     convertStringArr(prefixes),
 	}
@@ -145,7 +151,7 @@ func resourceRegistryUpdate(d *schema.ResourceData, m interface{}) error {
 	if scannerType == "" {
 		scannerType = "any"
 	}
-	if d.HasChanges("name", "username", "password", "url", "type", "auto_pull", "auto_pull_max", "auto_pull_time", "prefixes") {
+	if d.HasChanges("name", "username", "password", "url", "type", "auto_pull", "auto_pull_max", "auto_pull_time", "auto_pull_interval", "prefixes") {
 		prefixes := d.Get("prefixes").([]interface{})
 		registry := client.Registry{
 			Name:         d.Get("name").(string),
@@ -156,6 +162,7 @@ func resourceRegistryUpdate(d *schema.ResourceData, m interface{}) error {
 			AutoPull:     d.Get("auto_pull").(bool),
 			AutoPullMax:  d.Get("auto_pull_max").(int),
 			AutoPullTime: d.Get("auto_pull_time").(string),
+			AutoPullInterval: d.Get("auto_pull_interval").(int),
 			ScannerType:  scannerType,
 			Prefixes:     convertStringArr(prefixes),
 		}

--- a/client/registries.go
+++ b/client/registries.go
@@ -22,6 +22,7 @@ type Registry struct {
 	AutoPull                 bool        `json:"auto_pull"`
 	AutoPullTime             string      `json:"auto_pull_time"`
 	AutoPullMax              int         `json:"auto_pull_max"`
+	AutoPullInterval         int         `json:"auto_pull_interval"`
 	PullRepoPatterns         interface{} `json:"pull_repo_patterns"`
 	PullRepoPatternsExcluded interface{} `json:"pull_repo_patterns_excluded"`
 	PullTagPatterns          interface{} `json:"pull_tag_patterns"`


### PR DESCRIPTION
Fix for issue https://github.com/aquasecurity/terraform-provider-aquasec/issues/158

When configuring automatic scan for registry integration, the console requires the auto_pull_interval value