### PR TITLE
feat: Add proxy awareness via https_proxy env variable

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
-	"os"
+	neturl "net/url"
 
 	"github.com/aquasecurity/terraform-provider-aquasec/consts"
 	"github.com/parnurzeal/gorequest"
+	"golang.org/x/net/http/httpproxy"
 )
 
 // Client - API client
@@ -51,9 +52,11 @@ func NewClient(url, user, password string, verifyTLS bool, caCertByte []byte) *C
 		gorequest: gorequest.New().TLSClientConfig(tlsConfig),
 	}
 
-	proxy := os.Getenv("https_proxy")
-	if len(proxy) > 0 {
-		c.gorequest.Proxy(proxy)
+	// Determine if we need to use a proxy
+	uURL, _ := neturl.Parse(c.url)
+	proxy, _:= httpproxy.FromEnvironment().ProxyFunc()(uURL)
+	if proxy != nil {
+		c.gorequest.Proxy(proxy.String())
 	}
 
 	switch url {

--- a/client/client.go
+++ b/client/client.go
@@ -5,9 +5,11 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"log"
+	"os"
+
 	"github.com/aquasecurity/terraform-provider-aquasec/consts"
 	"github.com/parnurzeal/gorequest"
-	"log"
 )
 
 // Client - API client
@@ -47,6 +49,11 @@ func NewClient(url, user, password string, verifyTLS bool, caCertByte []byte) *C
 		user:      user,
 		password:  password,
 		gorequest: gorequest.New().TLSClientConfig(tlsConfig),
+	}
+
+	proxy := os.Getenv("https_proxy")
+	if len(proxy) > 0 {
+		c.gorequest.Proxy(proxy)
 	}
 
 	switch url {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/parnurzeal/gorequest v0.2.16
 	github.com/pkg/errors v0.9.1
+	golang.org/x/net v0.0.0-20220728030405-41545e8bf201
 )
 
 require (
@@ -65,8 +66,7 @@ require (
 	github.com/vmihailenco/tagparser v0.1.1 // indirect
 	github.com/zclconf/go-cty v1.10.0 // indirect
 	golang.org/x/crypto v0.0.0-20220622213112-05595931fe9d // indirect
-	golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 // indirect
-	golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b // indirect
+	golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	google.golang.org/appengine v1.6.6 // indirect
 	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,9 @@ golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwY
 golang.org/x/net v0.0.0-20210119194325-5f4716e94777/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20210326060303-6b1517762897/go.mod h1:uSPa2vr4CLtc/ILN5odXGNXS6mhrKVzTaCXzk9m6W3k=
-golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2 h1:CIJ76btIcR3eFI5EgSo6k1qKw9KJexJuRLI9G7Hp5wE=
 golang.org/x/net v0.0.0-20211112202133-69e39bad7dc2/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20220728030405-41545e8bf201 h1:bvOltf3SADAfG05iRml8lAB3qjoEX5RCyN4K6G5v3N0=
+golang.org/x/net v0.0.0-20220728030405-41545e8bf201/go.mod h1:YDH+HFinaLZZlnHAfSS6ZXJJ9M9t4Dl22yv3iI2vPwk=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -358,10 +359,12 @@ golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b h1:2n253B2r0pYSmEV+UNCQoPfU/FiaizQEK5Gu4Bq4JE8=
 golang.org/x/sys v0.0.0-20220627191245-f75cf1eec38b/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10 h1:WIoqL4EROvwiPdUtaip4VcDdpZ4kha7wBWZrbVKCIZg=
+golang.org/x/sys v0.0.0-20220728004956-3c1f35247d10/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=
+golang.org/x/term v0.0.0-20210927222741-03fcf44c2211/go.mod h1:jbD1KX2456YbFQfuXm/mYQcufACuNUgVhRMnK/tPxf8=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=


### PR DESCRIPTION
Fixes #165

Tested it locally setting the proxy to a random url:

```console
$ echo $https_proxy
http://172.17.113.143:30001
```

Then run a TF plan with DEBUG on:
```console
$ TF_LOG_PROVIDER=debug terraform plan
2022-07-26T18:47:08.878+0200 [INFO]  provider: configuring client automatic mTLS
2022-07-26T18:47:08.902+0200 [DEBUG] provider: starting plugin: path=.terraform/providers/github.com/aquasec/aquasec/0.8.13/linux_amd64/terraform-provider-aquasec args=[.terraform/providers/github.com/aquasec/aquasec/0.8.13/linux_amd64/terraform-provider-aquasec]
(..)
2022-07-26T18:49:19.348+0200 [ERROR] provider.terraform-provider-aquasec: Response contains error diagnostic: @caller=/home/mkilchhofer/git/github/terraform-provider-aquasec/vendor/github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/diag/diagnostics.go:56 diagnostic_severity=ERROR tf_req_id=e6b4d1a5-04d9-c062-8659-e652217fe45b @module=sdk.proto diagnostic_detail="Post "https://<REDACTED>.cloud.aquasec.com/api/v1/login": proxyconnect tcp: dial tcp 172.17.113.143:30001: connect: connection timed out" diagnostic_summary="Unable to fetch token" tf_proto_version=5.3 tf_provider_addr=provider tf_rpc=Configure timestamp=2022-07-26T18:49:19.347+0200
╷
│ Error: Unable to fetch token
│
│   with provider["github.com/aquasec/aquasec"],
│   on provider.tf line 1, in provider "aquasec":
│    1: provider "aquasec" {
│
│ Post "https://<REDACTED>.cloud.aquasec.com/api/v1/login": proxyconnect tcp: dial tcp 172.17.113.143:30001: connect: connection timed out
╵
2022-07-26T18:49:19.361+0200 [DEBUG] provider.stdio: received EOF, stopping recv loop: err="rpc error: code = Unavailable desc = transport is closing"
2022-07-26T18:49:19.364+0200 [DEBUG] provider: plugin process exited: path=.terraform/providers/github.com/aquasec/aquasec/0.8.13/linux_amd64/terraform-provider-aquasec pid=30847
2022-07-26T18:49:19.364+0200 [DEBUG] provider: plugin exited
```

Now starting a local proxy server (used this one here: https://github.com/genotrance/px). And rerun the plan:

```console
$ terraform plan
data.aquasec_gateways.current: Reading...
data.aquasec_gateways.current: Read complete after 1s [id=aqua-gateway-csp-<REDACTED>]
aquasec_enforcer_groups.sandbox_kube_enforcer: Refreshing state... [id=eks-<REDACTED>]
aquasec_enforcer_groups.sandbox_aqua_enforcer: Refreshing state... [id=eks-<REDACTED>-enforcer]

No changes. Your infrastructure matches the configuration.

Terraform has compared your real infrastructure against your configuration and found no differences, so no changes are needed.
```