### PR TITLE
fix scope_variable attribute name in runtime policies and service

### DIFF
--- a/aquasec/data_container_runtime_policy.go
+++ b/aquasec/data_container_runtime_policy.go
@@ -45,6 +45,11 @@ func dataContainerRuntimePolicy() *schema.Resource {
 							Description: "Class of supported scope.",
 							Computed:    true,
 						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Name assigned to the attribute.",
+							Optional:    true,
+						},
 						"value": {
 							Type:        schema.TypeString,
 							Description: "Value assigned to the attribute.",

--- a/aquasec/data_function_runtime_policy.go
+++ b/aquasec/data_function_runtime_policy.go
@@ -45,6 +45,11 @@ func dataFunctionRuntimePolicy() *schema.Resource {
 							Description: "Class of supported scope.",
 							Computed:    true,
 						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Name assigned to the attribute.",
+							Optional:    true,
+						},
 						"value": {
 							Type:        schema.TypeString,
 							Description: "Value assigned to the attribute.",

--- a/aquasec/data_host_runtime_policy.go
+++ b/aquasec/data_host_runtime_policy.go
@@ -45,6 +45,11 @@ func dataHostRuntimePolicy() *schema.Resource {
 							Description: "Class of supported scope.",
 							Computed:    true,
 						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Name assigned to the attribute.",
+							Optional:    true,
+						},
 						"value": {
 							Type:        schema.TypeString,
 							Description: "Value assigned to the attribute.",

--- a/aquasec/data_service.go
+++ b/aquasec/data_service.go
@@ -75,6 +75,11 @@ func dataSourceService() *schema.Resource {
 							Description: "Class of supported scope.",
 							Computed:    true,
 						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Name assigned to the attribute.",
+							Optional:    true,
+						},
 						"value": {
 							Type:        schema.TypeString,
 							Description: "Value assigned to the attribute.",

--- a/aquasec/resource_container_runtime_policy.go
+++ b/aquasec/resource_container_runtime_policy.go
@@ -54,6 +54,11 @@ func resourceContainerRuntimePolicy() *schema.Resource {
 							Description: "Class of supported scope.",
 							Required:    true,
 						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Name assigned to the attribute.",
+							Optional:    true,
+						},
 						"value": {
 							Type:        schema.TypeString,
 							Description: "Value assigned to the attribute.",
@@ -622,6 +627,7 @@ func expandContainerRuntimePolicy(d *schema.ResourceData) *client.RuntimePolicy 
 			ifc := v.(map[string]interface{})
 			variables = append(variables, client.Variable{
 				Attribute: ifc["attribute"].(string),
+				Name:      ifc["name"].(string),
 				Value:     ifc["value"].(string),
 			})
 		}

--- a/aquasec/resource_function_runtime_policy.go
+++ b/aquasec/resource_function_runtime_policy.go
@@ -54,6 +54,11 @@ func resourceFunctionRuntimePolicy() *schema.Resource {
 							Description: "Class of supported scope.",
 							Required:    true,
 						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Name assigned to the attribute.",
+							Optional:    true,
+						},
 						"value": {
 							Type:        schema.TypeString,
 							Description: "Value assigned to the attribute.",
@@ -260,6 +265,7 @@ func expandFunctionRuntimePolicy(d *schema.ResourceData) *client.RuntimePolicy {
 			ifc := v.(map[string]interface{})
 			variables = append(variables, client.Variable{
 				Attribute: ifc["attribute"].(string),
+				Name:      ifc["name"].(string),
 				Value:     ifc["value"].(string),
 			})
 		}

--- a/aquasec/resource_host_runtime_policy.go
+++ b/aquasec/resource_host_runtime_policy.go
@@ -54,6 +54,11 @@ func resourceHostRuntimePolicy() *schema.Resource {
 							Description: "Class of supported scope.",
 							Required:    true,
 						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Name assigned to the attribute.",
+							Optional:    true,
+						},
 						"value": {
 							Type:        schema.TypeString,
 							Description: "Value assigned to the attribute.",
@@ -638,6 +643,7 @@ func expandHostRuntimePolicy(d *schema.ResourceData) *client.RuntimePolicy {
 			ifc := v.(map[string]interface{})
 			variables = append(variables, client.Variable{
 				Attribute: ifc["attribute"].(string),
+				Name:      ifc["name"].(string),
 				Value:     ifc["value"].(string),
 			})
 		}

--- a/aquasec/resource_service.go
+++ b/aquasec/resource_service.go
@@ -73,7 +73,7 @@ func resourceService() *schema.Resource {
 			"scope_expression": {
 				Type:        schema.TypeString,
 				Description: "Logical expression of how to compute the dependency of the scope variables.",
-				Required:    true,
+				Optional:    true,
 			},
 			"scope_variables": {
 				Type:        schema.TypeList,
@@ -83,16 +83,16 @@ func resourceService() *schema.Resource {
 						"attribute": {
 							Type:        schema.TypeString,
 							Description: "Class of supported scope.",
-							Required:    true,
+							Optional:    true,
 						},
 						"value": {
 							Type:        schema.TypeString,
 							Description: "Value assigned to the attribute.",
-							Required:    true,
+							Optional:    true,
 						},
 					},
 				},
-				Required: true,
+				Optional: true,
 			},
 			"policies": {
 				Type: schema.TypeList,

--- a/aquasec/resource_service.go
+++ b/aquasec/resource_service.go
@@ -85,6 +85,11 @@ func resourceService() *schema.Resource {
 							Description: "Class of supported scope.",
 							Optional:    true,
 						},
+						"name": {
+							Type:        schema.TypeString,
+							Description: "Name assigned to the attribute.",
+							Optional:    true,
+						},
 						"value": {
 							Type:        schema.TypeString,
 							Description: "Value assigned to the attribute.",
@@ -369,6 +374,7 @@ func expandService(d *schema.ResourceData) *client.Service {
 			ifc := v.(map[string]interface{})
 			variables = append(variables, client.Variable{
 				Attribute: ifc["attribute"].(string),
+				Name:      ifc["name"].(string),
 				Value:     ifc["value"].(string),
 			})
 		}
@@ -405,6 +411,7 @@ func flattenScopeVariables(variables []client.Variable) []map[string]interface{}
 	for i := range variables {
 		specs[i] = map[string]interface{}{
 			"attribute": variables[i].Attribute,
+			"name":      variables[i].Name,
 			"value":     variables[i].Value,
 		}
 	}

--- a/client/service.go
+++ b/client/service.go
@@ -54,6 +54,7 @@ type Scope struct {
 
 type Variable struct {
 	Attribute string `json:"attribute"`
+	Name      string `json:"name"`
 	Value     string `json:"value"`
 }
 

--- a/docs/data-sources/container_runtime_policy.md
+++ b/docs/data-sources/container_runtime_policy.md
@@ -107,6 +107,7 @@ Read-Only:
 Read-Only:
 
 - `attribute` (String)
+- `name` (String)
 - `value` (String)
 
 

--- a/docs/data-sources/function_runtime_policy.md
+++ b/docs/data-sources/function_runtime_policy.md
@@ -54,6 +54,7 @@ output "function_runtime_policy_details" {
 Read-Only:
 
 - `attribute` (String)
+- `name` (String)
 - `value` (String)
 
 

--- a/docs/data-sources/host_runtime_policy.md
+++ b/docs/data-sources/host_runtime_policy.md
@@ -101,6 +101,7 @@ Read-Only:
 Read-Only:
 
 - `attribute` (String)
+- `name` (String)
 - `value` (String)
 
 

--- a/docs/data-sources/service.md
+++ b/docs/data-sources/service.md
@@ -53,6 +53,7 @@ description: |-
 Read-Only:
 
 - `attribute` (String)
+- `name` (String)
 - `value` (String)
 
 

--- a/docs/resources/container_runtime_policy.md
+++ b/docs/resources/container_runtime_policy.md
@@ -207,4 +207,8 @@ Required:
 - `attribute` (String) Class of supported scope.
 - `value` (String) Value assigned to the attribute.
 
+Optional:
+
+- `name` (String) Name assigned to the attribute.
+
 

--- a/docs/resources/function_runtime_policy.md
+++ b/docs/resources/function_runtime_policy.md
@@ -68,4 +68,8 @@ Required:
 - `attribute` (String) Class of supported scope.
 - `value` (String) Value assigned to the attribute.
 
+Optional:
+
+- `name` (String) Name assigned to the attribute.
+
 

--- a/docs/resources/host_runtime_policy.md
+++ b/docs/resources/host_runtime_policy.md
@@ -166,6 +166,10 @@ Required:
 - `attribute` (String) Class of supported scope.
 - `value` (String) Value assigned to the attribute.
 
+Optional:
+
+- `name` (String) Name assigned to the attribute.
+
 
 <a id="nestedblock--windows_registry_monitoring"></a>
 ### Nested Schema for `windows_registry_monitoring`

--- a/docs/resources/kubernetes_assurance_policy.md
+++ b/docs/resources/kubernetes_assurance_policy.md
@@ -56,7 +56,6 @@ description: |-
 - `enforce_after_days` (Number)
 - `enforce_excessive_permissions` (Boolean)
 - `exceptional_monitored_malware_paths` (List of String)
-- `fail_cicd` (Boolean) Indicates if cicd failures will fail the image.
 - `forbidden_labels` (Block Set) (see [below for nested schema](#nestedblock--forbidden_labels))
 - `forbidden_labels_enabled` (Boolean)
 - `force_microenforcer` (Boolean)

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -20,8 +20,6 @@ description: |-
 - `application_scopes` (List of String) Indicates the application scope of the service.
 - `name` (String) The name of the service. It is recommended not to use whitespace characters in the name.
 - `policies` (List of String) The service's policies; an array of container firewall policy names.
-- `scope_expression` (String) Logical expression of how to compute the dependency of the scope variables.
-- `scope_variables` (Block List, Min: 1) List of scope attributes. (see [below for nested schema](#nestedblock--scope_variables))
 - `target` (String) Type of the workload. container or host.
 
 ### Optional
@@ -30,6 +28,8 @@ description: |-
 - `enforce` (Boolean) Enforcement status of the service.
 - `monitoring` (Boolean) Indicates if monitoring is enabled or not
 - `priority` (Number) Rules priority, must be between 1-100.
+- `scope_expression` (String) Logical expression of how to compute the dependency of the scope variables.
+- `scope_variables` (Block List) List of scope attributes. (see [below for nested schema](#nestedblock--scope_variables))
 
 ### Read-Only
 
@@ -53,7 +53,7 @@ description: |-
 <a id="nestedblock--scope_variables"></a>
 ### Nested Schema for `scope_variables`
 
-Required:
+Optional:
 
 - `attribute` (String) Class of supported scope.
 - `value` (String) Value assigned to the attribute.

--- a/docs/resources/service.md
+++ b/docs/resources/service.md
@@ -56,6 +56,7 @@ description: |-
 Optional:
 
 - `attribute` (String) Class of supported scope.
+- `name` (String) Name assigned to the attribute.
 - `value` (String) Value assigned to the attribute.
 
 


### PR DESCRIPTION
fix #192 

fix scope_variable attribute name in runtime policies and service resources