### PR TITLE
bug: Container Runtime policy drift prevention: 'Allowed processes' not supported

### DIFF
--- a/aquasec/data_container_runtime_policy.go
+++ b/aquasec/data_container_runtime_policy.go
@@ -165,6 +165,14 @@ func dataContainerRuntimePolicy() *schema.Resource {
 				Description: "If true, executables that are not in the original image is prevented from running.",
 				Computed:    true,
 			},
+			"exec_lockdown_white_list": {
+				Type:        schema.TypeList,
+				Description: "Specify processes that will be allowed",
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+				Computed: true,
+			},
 			"allowed_executables": {
 				Type:        schema.TypeList,
 				Description: "List of executables that are allowed for the user.",
@@ -488,6 +496,7 @@ func dataContainerRuntimePolicyRead(ctx context.Context, d *schema.ResourceData,
 		d.Set("blocked_capabilities", crp.LinuxCapabilities.RemoveLinuxCapabilities)
 		d.Set("enable_ip_reputation_security", crp.EnableIPReputation)
 		d.Set("enable_drift_prevention", crp.DriftPrevention.Enabled && crp.DriftPrevention.ExecLockdown)
+		d.Set("exec_lockdown_white_list", crp.DriftPrevention.ExecLockdownWhiteList)
 		d.Set("allowed_executables", crp.AllowedExecutables.AllowExecutables)
 		d.Set("blocked_executables", crp.ExecutableBlacklist.Executables)
 		d.Set("blocked_files", crp.FileBlock.FilenameBlockList)

--- a/docs/data-sources/container_runtime_policy.md
+++ b/docs/data-sources/container_runtime_policy.md
@@ -72,6 +72,7 @@ output "container_runtime_policy_details" {
 - `enforce` (Boolean) Indicates that policy should effect container execution (not just for audit).
 - `enforce_after_days` (Number) Indicates the number of days after which the runtime policy will be changed to enforce mode.
 - `exceptional_readonly_files_and_directories` (List of String) List of files and directories to be excluded from the read-only list.
+- `exec_lockdown_white_list` (List of String) Specify processes that will be allowed
 - `file_integrity_monitoring` (List of Object) Configuration for file integrity monitoring. (see [below for nested schema](#nestedatt--file_integrity_monitoring))
 - `fork_guard_process_limit` (Number) Process limit for the fork guard.
 - `id` (String) The ID of this resource.

--- a/docs/resources/container_runtime_policy.md
+++ b/docs/resources/container_runtime_policy.md
@@ -185,6 +185,7 @@ resource "aquasec_container_runtime_policy" "container_runtime_policy" {
 - `enforce` (Boolean) Indicates that policy should effect container execution (not just for audit).
 - `enforce_after_days` (Number) Indicates the number of days after which the runtime policy will be changed to enforce mode.
 - `exceptional_readonly_files_and_directories` (List of String) List of files and directories to be excluded from the read-only list.
+- `exec_lockdown_white_list` (List of String) Specify processes that will be allowed
 - `file_integrity_monitoring` (Block List, Max: 1) Configuration for file integrity monitoring. (see [below for nested schema](#nestedblock--file_integrity_monitoring))
 - `fork_guard_process_limit` (Number) Process limit for the fork guard.
 - `limit_new_privileges` (Boolean) If true, prevents the container from obtaining new privileges at runtime. (only enabled in enforce mode)


### PR DESCRIPTION
bug: fixing Terraform provider: Container Runtime policy drift prevention: 'Allowed processes' not supported