### PR TITLE
fix: Use correct tokenUrl and fix typos (Sass -> SaaS)

### DIFF
--- a/aquasec/data_role_mapping_sass.go
+++ b/aquasec/data_role_mapping_sass.go
@@ -3,6 +3,7 @@ package aquasec
 import (
 	"context"
 	"fmt"
+
 	"github.com/aquasecurity/terraform-provider-aquasec/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -49,7 +50,7 @@ func dataSourceRolesMappingSaas() *schema.Resource {
 
 func dataRolesMappingSaasRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.Client)
-	result, err := c.GetRolesMappingSass()
+	result, err := c.GetRolesMappingSaas()
 	if err == nil {
 		rolesMappingSaas, id := flattenRolesMappingSaasData(result)
 		d.SetId(id)

--- a/aquasec/resource_role_mapping_saas.go
+++ b/aquasec/resource_role_mapping_saas.go
@@ -3,11 +3,12 @@ package aquasec
 import (
 	"context"
 	"fmt"
+	"log"
+	"strings"
+
 	"github.com/aquasecurity/terraform-provider-aquasec/client"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"log"
-	"strings"
 )
 
 func resourceRoleMappingSaas() *schema.Resource {
@@ -51,7 +52,7 @@ func resourceRoleMappingSaas() *schema.Resource {
 func resourceRoleMappingSaasRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	ac := m.(*client.Client)
 
-	r, err := ac.GetRoleMappingSass(d.Id())
+	r, err := ac.GetRoleMappingSaas(d.Id())
 	if err == nil {
 		d.Set("role_mapping_id", r.Id)
 		d.Set("created", r.Created)
@@ -103,7 +104,7 @@ func resourceRoleMappingSaasUpdate(ctx context.Context, d *schema.ResourceData, 
 
 func resourceRoleMappingSaasDelete(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.Client)
-	err := c.DeleteRoleMappingSass(d.Id())
+	err := c.DeleteRoleMappingSaas(d.Id())
 	if err == nil {
 		d.SetId("")
 	} else {

--- a/client/group.go
+++ b/client/group.go
@@ -33,7 +33,7 @@ func (cli *Client) GetGroup(id int) (*Group, error) {
 		apiPath = fmt.Sprintf("/v2/groups/%v", id)
 		baseUrl = cli.tokenUrl
 	} else {
-		err = fmt.Errorf("GetGroup is Supported only in Auaa SAAS")
+		err = fmt.Errorf("GetGroup is Supported only in Aqua SaaS env")
 		return nil, err
 	}
 
@@ -69,7 +69,7 @@ func (cli *Client) GetGroups() ([]Group, error) {
 		apiPath = "/v2/groups"
 		baseUrl = cli.tokenUrl
 	} else {
-		err = fmt.Errorf("GetGroups is Supported only in Auaa SAAS")
+		err = fmt.Errorf("GetGroups is Supported only in Aqua SaaS env")
 		return nil, err
 	}
 
@@ -104,7 +104,7 @@ func (cli *Client) CreateGroup(group *Group) error {
 		apiPath = "/v2/groups"
 		baseUrl = cli.tokenUrl
 	} else {
-		err = fmt.Errorf("CreateGroup is Supported only in Auaa SAAS")
+		err = fmt.Errorf("CreateGroup is Supported only in Aqua SaaS env")
 		return err
 	}
 
@@ -143,7 +143,7 @@ func (cli *Client) UpdateGroup(group *Group) error {
 		apiPath = fmt.Sprintf("/v2/groups/%v", group.Id)
 		baseUrl = cli.tokenUrl
 	} else {
-		err = fmt.Errorf("UpdateGroup is Supported only in Auaa SAAS")
+		err = fmt.Errorf("UpdateGroup is Supported only in Aqua SaaS env")
 		return err
 	}
 
@@ -175,7 +175,7 @@ func (cli *Client) DeleteGroup(id string) error {
 		apiPath = fmt.Sprintf("/v2/groups/%v", id)
 		baseUrl = cli.tokenUrl
 	} else {
-		err = fmt.Errorf("DeleteGroup is Supported only in Auaa SAAS")
+		err = fmt.Errorf("DeleteGroup is Supported only in Aqua SaaS env")
 		return err
 	}
 

--- a/client/sso.go
+++ b/client/sso.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	json "encoding/json"
 	"fmt"
+	"log"
+
 	"github.com/aquasecurity/terraform-provider-aquasec/consts"
 	"github.com/pkg/errors"
-	"log"
 )
 
 type Saml struct {
@@ -279,22 +280,22 @@ func (cli *Client) createSsoBasic(apiPath string, sso interface{}) error {
 	return nil
 }
 
-// GetRoleMappingSass - returns Aqua RoleMappingSaas
-func (cli *Client) GetRoleMappingSass(id string) (*RoleMappingSaas, error) {
+// GetRoleMappingSaas - returns Aqua RoleMappingSaas
+func (cli *Client) GetRoleMappingSaas(id string) (*RoleMappingSaas, error) {
 	var err error
 	var response RoleMappingSaas
 	baseUrl := ""
 	apiPath := fmt.Sprintf("/v2/samlmappings/%s", id)
 	switch cli.clientType {
 	case Csp:
-		err = fmt.Errorf("GetRoleMappingSass is Supported only in Aqua SASS env")
+		err = fmt.Errorf("GetRoleMappingSaas is Supported only in Aqua SaaS env")
 		return nil, err
 	case SaasDev:
 		baseUrl = consts.SaasDevTokenUrl
 	case Saas:
 		baseUrl = consts.SaasTokenUrl
 	default:
-		err = fmt.Errorf("GetRoleMappingSass is Supported only in Aqua SASS env")
+		err = fmt.Errorf("GetRoleMappingSaas is Supported only in Aqua SaaS env")
 		return nil, err
 	}
 
@@ -317,7 +318,7 @@ func (cli *Client) GetRoleMappingSass(id string) (*RoleMappingSaas, error) {
 
 	err = json.Unmarshal([]byte(body), &response)
 	if err != nil {
-		log.Printf("Error calling func GetRolesMappingSass from %s%s, %v ", baseUrl, apiPath, err)
+		log.Printf("Error calling func GetRoleMappingSaas from %s%s, %v ", baseUrl, apiPath, err)
 		return nil, errors.Wrap(err, "could not unmarshal roleMappingSaas response")
 	}
 
@@ -325,8 +326,8 @@ func (cli *Client) GetRoleMappingSass(id string) (*RoleMappingSaas, error) {
 
 }
 
-// GetRolesMappingSass - returns Aqua RoleMappingSaas
-func (cli *Client) GetRolesMappingSass() (*RoleMappingSaasList, error) {
+// GetRolesMappingSaas - returns Aqua RoleMappingSaas
+func (cli *Client) GetRolesMappingSaas() (*RoleMappingSaasList, error) {
 	var err error
 	var response RoleMappingSaasList
 	baseUrl := ""
@@ -334,14 +335,14 @@ func (cli *Client) GetRolesMappingSass() (*RoleMappingSaasList, error) {
 
 	switch cli.clientType {
 	case Csp:
-		err = fmt.Errorf("GetRolesMappingSass is Supported only in Aqua SASS env")
+		err = fmt.Errorf("GetRolesMappingSaas is Supported only in Aqua SaaS env")
 		return nil, err
 	case SaasDev:
 		baseUrl = consts.SaasDevTokenUrl
 	case Saas:
 		baseUrl = consts.SaasTokenUrl
 	default:
-		err = fmt.Errorf("GetRolesMappingSass is Supported only in Aqua SASS env")
+		err = fmt.Errorf("GetRolesMappingSaas is Supported only in Aqua SaaS env")
 		return nil, err
 	}
 
@@ -364,7 +365,7 @@ func (cli *Client) GetRolesMappingSass() (*RoleMappingSaasList, error) {
 
 	err = json.Unmarshal([]byte(body), &response)
 	if err != nil {
-		log.Printf("Error calling func GetRolesMappingSass from %s%s, %v ", baseUrl, apiPath, err)
+		log.Printf("Error calling func GetRolesMappingSaas from %s%s, %v ", baseUrl, apiPath, err)
 		return nil, errors.Wrap(err, "could not unmarshal roleMappingSaasList response")
 	}
 
@@ -380,14 +381,14 @@ func (cli *Client) CreateRoleMappingSaas(saas *RoleMappingSaas) error {
 
 	switch cli.clientType {
 	case Csp:
-		err = fmt.Errorf("GetRolesMappingSass is Supported only in Aqua SASS env")
+		err = fmt.Errorf("CreateRoleMappingSaas is Supported only in Aqua SaaS env")
 		return err
 	case SaasDev:
 		baseUrl = consts.SaasDevTokenUrl
 	case Saas:
 		baseUrl = consts.SaasTokenUrl
 	default:
-		err = fmt.Errorf("GetRolesMappingSass is Supported only in Aqua SASS env")
+		err = fmt.Errorf("CreateRoleMappingSaas is Supported only in Aqua SaaS env")
 		return err
 	}
 	saasTmp := map[string]interface{}{
@@ -416,7 +417,7 @@ func (cli *Client) CreateRoleMappingSaas(saas *RoleMappingSaas) error {
 
 	err = json.Unmarshal([]byte(body), &roleMappingResponse)
 	if err != nil {
-		log.Printf("Error calling func GetRolesMappingSass from %s%s, %v ", baseUrl, apiPath, err)
+		log.Printf("Error calling func CreateRoleMappingSaas from %s%s, %v ", baseUrl, apiPath, err)
 		return errors.Wrap(err, "could not unmarshal roleMappingSaas response")
 	}
 	saas.Id = roleMappingResponse.RoleMappingSaas.Id
@@ -432,14 +433,14 @@ func (cli *Client) UpdateRoleMappingSaas(saas *RoleMappingSaas, id string) error
 
 	switch cli.clientType {
 	case Csp:
-		err = fmt.Errorf("GetRolesMappingSass is Supported only in Aqua SASS env")
+		err = fmt.Errorf("UpdateRoleMappingSaas is Supported only in Aqua SaaS env")
 		return err
 	case SaasDev:
 		baseUrl = consts.SaasDevTokenUrl
 	case Saas:
 		baseUrl = consts.SaasTokenUrl
 	default:
-		err = fmt.Errorf("GetRolesMappingSass is Supported only in Aqua SASS env")
+		err = fmt.Errorf("UpdateRoleMappingSaas is Supported only in Aqua SaaS env")
 		return err
 	}
 	saasTmp := map[string]interface{}{
@@ -466,28 +467,28 @@ func (cli *Client) UpdateRoleMappingSaas(saas *RoleMappingSaas, id string) error
 
 	//err = json.Unmarshal([]byte(body), &saas)
 	//if err != nil {
-	//	log.Printf("Error calling func GetRolesMappingSass from %s%s, %v ", baseUrl, apiPath, err)
+	//	log.Printf("Error calling func UpdateRoleMappingSaas from %s%s, %v ", baseUrl, apiPath, err)
 	//	return errors.Wrap(err, "could not unmarshal roleMappingSaas response")
 	//}
 
 	return nil
 }
 
-// DeleteRoleMappingSass - returns Aqua RoleMappingSaas
-func (cli *Client) DeleteRoleMappingSass(id string) error {
+// DeleteRoleMappingSaas - returns Aqua RoleMappingSaas
+func (cli *Client) DeleteRoleMappingSaas(id string) error {
 	var err error
 	baseUrl := ""
 	apiPath := fmt.Sprintf("/v2/samlmappings/%s", id)
 	switch cli.clientType {
 	case Csp:
-		err = fmt.Errorf("GetRoleMappingSass is Supported only in Aqua SASS env")
+		err = fmt.Errorf("DeleteRoleMappingSaas is Supported only in Aqua SaaS env")
 		return err
 	case SaasDev:
 		baseUrl = consts.SaasDevTokenUrl
 	case Saas:
 		baseUrl = consts.SaasTokenUrl
 	default:
-		err = fmt.Errorf("GetRoleMappingSass is Supported only in Aqua SASS env")
+		err = fmt.Errorf("DeleteRoleMappingSaas is Supported only in Aqua SaaS env")
 		return err
 	}
 

--- a/client/sso.go
+++ b/client/sso.go
@@ -286,15 +286,10 @@ func (cli *Client) GetRoleMappingSaas(id string) (*RoleMappingSaas, error) {
 	var response RoleMappingSaas
 	baseUrl := ""
 	apiPath := fmt.Sprintf("/v2/samlmappings/%s", id)
-	switch cli.clientType {
-	case Csp:
-		err = fmt.Errorf("GetRoleMappingSaas is Supported only in Aqua SaaS env")
-		return nil, err
-	case SaasDev:
-		baseUrl = consts.SaasDevTokenUrl
-	case Saas:
-		baseUrl = consts.SaasTokenUrl
-	default:
+
+	if cli.clientType == Saas || cli.clientType == SaasDev {
+		baseUrl = cli.tokenUrl
+	} else {
 		err = fmt.Errorf("GetRoleMappingSaas is Supported only in Aqua SaaS env")
 		return nil, err
 	}
@@ -333,15 +328,9 @@ func (cli *Client) GetRolesMappingSaas() (*RoleMappingSaasList, error) {
 	baseUrl := ""
 	apiPath := "/v2/samlmappings"
 
-	switch cli.clientType {
-	case Csp:
-		err = fmt.Errorf("GetRolesMappingSaas is Supported only in Aqua SaaS env")
-		return nil, err
-	case SaasDev:
-		baseUrl = consts.SaasDevTokenUrl
-	case Saas:
-		baseUrl = consts.SaasTokenUrl
-	default:
+	if cli.clientType == Saas || cli.clientType == SaasDev {
+		baseUrl = cli.tokenUrl
+	} else {
 		err = fmt.Errorf("GetRolesMappingSaas is Supported only in Aqua SaaS env")
 		return nil, err
 	}
@@ -379,18 +368,13 @@ func (cli *Client) CreateRoleMappingSaas(saas *RoleMappingSaas) error {
 	baseUrl := ""
 	apiPath := "/v2/samlmappings"
 
-	switch cli.clientType {
-	case Csp:
-		err = fmt.Errorf("CreateRoleMappingSaas is Supported only in Aqua SaaS env")
-		return err
-	case SaasDev:
-		baseUrl = consts.SaasDevTokenUrl
-	case Saas:
-		baseUrl = consts.SaasTokenUrl
-	default:
+	if cli.clientType == Saas || cli.clientType == SaasDev {
+		baseUrl = cli.tokenUrl
+	} else {
 		err = fmt.Errorf("CreateRoleMappingSaas is Supported only in Aqua SaaS env")
 		return err
 	}
+
 	saasTmp := map[string]interface{}{
 		"csp_role":    saas.CspRole,
 		"saml_groups": saas.SamlGroups,
@@ -431,18 +415,13 @@ func (cli *Client) UpdateRoleMappingSaas(saas *RoleMappingSaas, id string) error
 	baseUrl := ""
 	apiPath := fmt.Sprintf("/v2/samlmappings/%s", id)
 
-	switch cli.clientType {
-	case Csp:
-		err = fmt.Errorf("UpdateRoleMappingSaas is Supported only in Aqua SaaS env")
-		return err
-	case SaasDev:
-		baseUrl = consts.SaasDevTokenUrl
-	case Saas:
-		baseUrl = consts.SaasTokenUrl
-	default:
+	if cli.clientType == Saas || cli.clientType == SaasDev {
+		baseUrl = cli.tokenUrl
+	} else {
 		err = fmt.Errorf("UpdateRoleMappingSaas is Supported only in Aqua SaaS env")
 		return err
 	}
+
 	saasTmp := map[string]interface{}{
 		"saml_groups": saas.SamlGroups,
 	}
@@ -479,15 +458,10 @@ func (cli *Client) DeleteRoleMappingSaas(id string) error {
 	var err error
 	baseUrl := ""
 	apiPath := fmt.Sprintf("/v2/samlmappings/%s", id)
-	switch cli.clientType {
-	case Csp:
-		err = fmt.Errorf("DeleteRoleMappingSaas is Supported only in Aqua SaaS env")
-		return err
-	case SaasDev:
-		baseUrl = consts.SaasDevTokenUrl
-	case Saas:
-		baseUrl = consts.SaasTokenUrl
-	default:
+
+	if cli.clientType == Saas || cli.clientType == SaasDev {
+		baseUrl = cli.tokenUrl
+	} else {
 		err = fmt.Errorf("DeleteRoleMappingSaas is Supported only in Aqua SaaS env")
 		return err
 	}

--- a/client/user.go
+++ b/client/user.go
@@ -45,7 +45,7 @@ type BasicUser struct {
 	Type  string   `json:"type,omitempty"`
 	Plan  string   `json:"plan,omitempty"`
 
-	//SAAS vars:
+	//SaaS vars:
 	//Dashboard
 	CspRoles          []string     `json:"csp_roles,omitempty"`
 	Confirmed         bool         `json:"confirmed,omitempty"`
@@ -75,7 +75,7 @@ type NewPassword struct {
 	Password string `json:"new_password"`
 }
 
-//GetUser - returns single Aqua user
+// GetUser - returns single Aqua user
 func (cli *Client) GetUser(name string) (*FullUser, error) {
 	var err error
 	var response FullUser
@@ -117,7 +117,7 @@ func (cli *Client) GetUser(name string) (*FullUser, error) {
 	return &response, err
 }
 
-//GetUsers - returns all Aqua users
+// GetUsers - returns all Aqua users
 func (cli *Client) GetUsers() ([]FullUser, error) {
 	var err error
 	var response []FullUser


### PR DESCRIPTION
It seems that the resource `aquasec_role_mapping_saas` today only works for the default SaaS region. The other regions `eu-1`, `asia-1` and `asia-2` cannot work with todays implementation.

Fixes #244
While here, I also fixed typos inside class names and comments.

Before change:
![wrong token API baseurl](https://user-images.githubusercontent.com/7290987/229634373-a4e2c5f0-2f76-47d7-8f70-fd5dafb435d1.png)


After change:
![correct token API baseurl](https://user-images.githubusercontent.com/7290987/229634286-be833219-f61c-4a9e-9e94-3782afc0802c.png)
(Traces/screenshots are made using [github.com/mitmproxy](https://github.com/mitmproxy/mitmproxy).)


/cc: @BaruchBilanski , @yossig-aquasec , @blanchardma , @the-technat
