### PR TITLE
fix: Package io/ioutil is deprecated as of Go 1.16

### DIFF
--- a/aquasec/init_test.go
+++ b/aquasec/init_test.go
@@ -2,11 +2,11 @@ package aquasec
 
 import (
 	"fmt"
-	"github.com/aquasecurity/terraform-provider-aquasec/client"
-	"io/ioutil"
 	"log"
 	"os"
 	"strconv"
+
+	"github.com/aquasecurity/terraform-provider-aquasec/client"
 )
 
 func init() {
@@ -41,7 +41,7 @@ func init() {
 	caCertPath, present = os.LookupEnv("AQUA_CA_CERT_PATH")
 	if present {
 		if caCertPath != "" {
-			caCertByte, err = ioutil.ReadFile(caCertPath)
+			caCertByte, err = os.ReadFile(caCertPath)
 			if err != nil {
 				panic("Unable to read CA certificates")
 			}

--- a/aquasec/provider.go
+++ b/aquasec/provider.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -145,7 +145,7 @@ func getProviderConfigurationFromFile(d *schema.ResourceData) (string, string, s
 		}
 		defer configFile.Close()
 
-		configBytes, _ := ioutil.ReadAll(configFile)
+		configBytes, _ := io.ReadAll(configFile)
 		var config Config
 		err = json.Unmarshal(configBytes, &config)
 		if err != nil {
@@ -198,7 +198,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData) (interface{}
 
 	var caCertByte []byte
 	if caCertPath != "" {
-		caCertByte, err = ioutil.ReadFile(caCertPath)
+		caCertByte, err = os.ReadFile(caCertPath)
 		if err != nil {
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Error,

--- a/client/application_scope.go
+++ b/client/application_scope.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/pkg/errors"
@@ -52,7 +52,7 @@ type Variables struct {
 	Value     string `json:"value"`
 }
 
-//Get Application Scope
+// Get Application Scope
 func (cli *Client) GetApplicationScope(name string) (*ApplicationScope, error) {
 	var err error
 	var response ApplicationScope
@@ -73,7 +73,7 @@ func (cli *Client) GetApplicationScope(name string) (*ApplicationScope, error) {
 			return nil, err
 		}
 	} else {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return nil, err
@@ -110,7 +110,7 @@ func (cli *Client) CreateApplicationScope(applicationscope *ApplicationScope) er
 		return errors.Wrap(getMergedError(errs), "failed creating Application Scope.")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err
@@ -143,7 +143,7 @@ func (cli *Client) UpdateApplicationScope(applicationscope *ApplicationScope, na
 		return errors.Wrap(getMergedError(errs), "failed modifying Application Scope")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err
@@ -172,7 +172,7 @@ func (cli *Client) DeleteApplicationScope(name string) error {
 		return errors.Wrap(getMergedError(errs), "failed deleting Application Scope")
 	}
 	if resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err

--- a/client/assurance_policy.go
+++ b/client/assurance_policy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"strings"
 	"time"
@@ -175,7 +175,7 @@ func (cli *Client) GetAssurancePolicy(name string, at string) (*AssurancePolicy,
 			return nil, err
 		}
 	} else {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return nil, err
@@ -222,7 +222,7 @@ func (cli *Client) CreateAssurancePolicy(assurancepolicy *AssurancePolicy, at st
 		return errors.Wrap(getMergedError(errs), "failed creating  Assurance Policy.")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err
@@ -265,7 +265,7 @@ func (cli *Client) UpdateAssurancePolicy(assurancepolicy *AssurancePolicy, at st
 		return errors.Wrap(getMergedError(errs), "failed modifying  Assurance Policy")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err
@@ -304,7 +304,7 @@ func (cli *Client) DeleteAssurancePolicy(name string, at string) error {
 		return errors.Wrap(getMergedError(errs), "failed deleting  Assurance Policy")
 	}
 	if resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err

--- a/client/firewall_policy.go
+++ b/client/firewall_policy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/pkg/errors"
@@ -84,7 +84,7 @@ func (cli *Client) GetFirewallPolicy(name string) (*FirewallPolicy, error) {
 			return nil, err
 		}
 	} else {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return nil, err
@@ -121,7 +121,7 @@ func (cli *Client) CreateFirewallPolicy(firewallPolicy FirewallPolicy) error {
 		return errors.Wrap(getMergedError(errs), "failed creating firewall policy.")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err
@@ -154,7 +154,7 @@ func (cli *Client) UpdateFirewallPolicy(firewallPolicy FirewallPolicy) error {
 		return errors.Wrap(getMergedError(errs), "failed modifying firewall policy")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err
@@ -183,7 +183,7 @@ func (cli *Client) DeleteFirewallPolicy(name string) error {
 		return errors.Wrap(getMergedError(errs), "failed deleting firewall policy")
 	}
 	if resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err

--- a/client/image.go
+++ b/client/image.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"time"
 
@@ -199,7 +199,7 @@ func (cli *Client) RescanImage(image *Image, fullRescan bool) error {
 		return errors.Wrap(getMergedError(errs), "failed rescaning image")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err

--- a/client/labels.go
+++ b/client/labels.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/pkg/errors"
@@ -41,7 +41,7 @@ func (cli *Client) GetAquaLabel(name string) (*AquaLabel, error) {
 			return nil, err
 		}
 	} else {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return nil, err
@@ -80,7 +80,7 @@ func (cli *Client) GetAquaLabels() (*AquaLabels, error) {
 			return nil, err
 		}
 	} else {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return nil, err
@@ -115,7 +115,7 @@ func (cli *Client) CreateAquaLabel(aquaLabel *AquaLabel) error {
 		return errors.Wrap(getMergedError(errs), "failed creating Aqua label.")
 	}
 	if resp.StatusCode != 200 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err
@@ -148,7 +148,7 @@ func (cli *Client) UpdateAquaLabel(aquaLabel *AquaLabel) error {
 		return errors.Wrap(getMergedError(errs), "failed modifying Aqua label")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err
@@ -177,7 +177,7 @@ func (cli *Client) DeleteAquaLabel(name string) error {
 		return errors.Wrap(getMergedError(errs), "failed deleting Aqua label")
 	}
 	if resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err

--- a/client/notifications.go
+++ b/client/notifications.go
@@ -4,13 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/pkg/errors"
 )
 
-//NotificationOld defines a NotificationOld
+// NotificationOld defines a NotificationOld
 type NotificationOld struct {
 	Enabled    bool   `json:"enabled"`
 	Channel    string `json:"channel"`
@@ -95,7 +95,7 @@ func (cli *Client) GetNotification(id string) (*Notification, error) {
 			return nil, err
 		}
 	} else {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return nil, err
@@ -185,7 +185,7 @@ func (cli *Client) DeleteNotification(id string) error {
 		return err
 	}
 	if resp.StatusCode != 200 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err
@@ -202,7 +202,7 @@ func (cli *Client) DeleteNotification(id string) error {
 }
 
 // todo: Old Notification, should be removed after next release
-//SlackNotificationCreate enables a Slack NotificationOld
+// SlackNotificationCreate enables a Slack NotificationOld
 func (cli *Client) SlackNotificationCreate(notification NotificationOld) error {
 	payload, err := json.Marshal(notification)
 	if err != nil {
@@ -225,7 +225,7 @@ func (cli *Client) SlackNotificationCreate(notification NotificationOld) error {
 	return nil
 }
 
-//SlackNotificationUpdate enables/disables a Slack NotificationOld
+// SlackNotificationUpdate enables/disables a Slack NotificationOld
 func (cli *Client) SlackNotificationUpdate(notification NotificationOld) error {
 	payload, err := json.Marshal(notification)
 	if err != nil {
@@ -247,7 +247,7 @@ func (cli *Client) SlackNotificationUpdate(notification NotificationOld) error {
 	return nil
 }
 
-//SlackNotificationRead reads the given slack configurations
+// SlackNotificationRead reads the given slack configurations
 func (cli *Client) SlackNotificationRead() (*NotificationOld, error) {
 	var err error
 	var response NotificationOld
@@ -273,9 +273,9 @@ func (cli *Client) SlackNotificationRead() (*NotificationOld, error) {
 	return &response, nil
 }
 
-//SlackNotificationDelete enables/disables a Slack NotificationOld
-//Since there is no DELETE method implementation of the API, we are basically setting the values as spaces
-//and setting the enabled indicator as false
+// SlackNotificationDelete enables/disables a Slack NotificationOld
+// Since there is no DELETE method implementation of the API, we are basically setting the values as spaces
+// and setting the enabled indicator as false
 func (cli *Client) SlackNotificationDelete(notification NotificationOld) error {
 	payload, err := json.Marshal(notification)
 	if err != nil {

--- a/client/permission_sets.go
+++ b/client/permission_sets.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/pkg/errors"
@@ -45,7 +45,7 @@ func (cli *Client) GetPermissionsSet(name string) (*PermissionsSet, error) {
 			return nil, err
 		}
 	} else {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return nil, err
@@ -116,7 +116,7 @@ func (cli *Client) CreatePermissionsSet(permissionset *PermissionsSet) error {
 		return errors.Wrap(getMergedError(errs), "failed creating PermissionSet.")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err
@@ -149,7 +149,7 @@ func (cli *Client) UpdatePermissionsSet(permissionset *PermissionsSet) error {
 		return errors.Wrap(getMergedError(errs), "failed modifying PermissionSet")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err
@@ -178,7 +178,7 @@ func (cli *Client) DeletePermissionsSet(name string) error {
 		return errors.Wrap(getMergedError(errs), "failed deleting PermissionSet")
 	}
 	if resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err

--- a/client/runtime_policy.go
+++ b/client/runtime_policy.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"time"
 
@@ -354,7 +354,7 @@ func (cli *Client) UpdateRuntimePolicy(runtimePolicy *RuntimePolicy) error {
 		return errors.Wrap(getMergedError(errs), "failed modifying runtime policy")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err

--- a/client/service.go
+++ b/client/service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 
 	"github.com/pkg/errors"
@@ -177,7 +177,7 @@ func (cli *Client) UpdateService(service *Service) error {
 		return errors.Wrap(getMergedError(errs), "failed modifying service")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			log.Printf("Failed to read response Body")
 			return err


### PR DESCRIPTION
> Package ioutil implements some I/O utility functions.
> 
> **Deprecated: As of Go 1.16**, the same functionality is now provided by package io or package os, and those implementations should be preferred in new code. See the specific function documentation for details. 

Ref: https://pkg.go.dev/io/ioutil


/cc: @BaruchBilanski , @yossig-aquasec