### PR TITLE
Fix saas user resource

### DIFF
--- a/client/user.go
+++ b/client/user.go
@@ -83,7 +83,7 @@ func (cli *Client) GetUser(name string) (*FullUser, error) {
 	apiPath := fmt.Sprintf("/api/v1/users/%s", name)
 	if cli.clientType == Saas || cli.clientType == SaasDev {
 		baseUrl = cli.tokenUrl
-		apiPath = fmt.Sprintf("/v2/users/%s/?expand=csproles,group", name)
+		apiPath = fmt.Sprintf("/v2/users/%s?expand=csproles,group", name)
 	}
 
 	request := cli.gorequest


### PR DESCRIPTION
Trailing slash on api call which was not required causing a bug in the provider when reading the results of a user creation