### PR TITLE
Added support for Name parameter under scope variables

### DIFF
--- a/aquasec/resource_container_runtime_policy.go
+++ b/aquasec/resource_container_runtime_policy.go
@@ -1231,6 +1231,10 @@ func resourceContainerRuntimePolicy() *schema.Resource {
 										Description: "Variable value.",
 										Required:    true,
 									},
+									"name": {
+										Type:     schema.TypeString,
+										Optional: true,
+									},
 								},
 							},
 						},

--- a/aquasec/resource_host_runtime_policy.go
+++ b/aquasec/resource_host_runtime_policy.go
@@ -3007,6 +3007,7 @@ func flattenVariables(variables []interface{}) []client.Variable {
 		val := v.(map[string]interface{})
 		result = append(result, client.Variable{
 			Attribute: val["attribute"].(string),
+                        Name:      val["name"].(string),
 			Value:     val["value"].(string),
 		})
 	}


### PR DESCRIPTION
Customer observed that scope is not reflecting as defined in terraform code after the container runtime policy is created.
Observed that container runtime policy is lacking name parameter as part of the scope.

I have added support for name parameter under scope.
Customer can use following syntax to post changes involved in this PR are released.

`resource "aquasec_container_runtime_policy" "container_runtime_policy_terraform_example" {
  name = "container_runtime_policy_terraform_1"
  description = "container_runtime_policy_terraform_1"
  scope_expression = "v1"

  # Correct definition of scope_variables as nested blocks
  scope {
    expression = "v1 || v2 || v3"
    variables {
      attribute = "kubernetes.cluster"
      value = "berto-clu"
    }
    variables {
      attribute = "kubernetes.label"
      value = "aqua"
      name = "app"
    }
    variables {
      attribute = "kubernetes.namespace"
      value = "aqua"
    }
  }

  application_scopes = [
    "Varada"
  ]
}
`