### PR TITLE
Fix host assurance policy schema and add example

### DIFF
--- a/aquasec/resource_host_assurance_policy.go
+++ b/aquasec/resource_host_assurance_policy.go
@@ -480,10 +480,7 @@ func resourceHostAssurancePolicy() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-			},
-			"enforce": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Computed: true,
 			},
 			"enforce_after_days": {
 				Type:     schema.TypeInt,
@@ -992,7 +989,6 @@ func resourceHostAssurancePolicyRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("cves_white_list", iap.CvesWhiteList)
 	d.Set("blacklist_permissions_enabled", iap.BlacklistPermissionsEnabled)
 	d.Set("blacklist_permissions", iap.BlacklistPermissions)
-	d.Set("enabled", iap.Enabled)
 	d.Set("enforce", iap.Enforce)
 	d.Set("enforce_after_days", iap.EnforceAfterDays)
 	d.Set("ignore_recently_published_vln", iap.IgnoreRecentlyPublishedVln)

--- a/examples/resources/aquasec_host_assurance_policy/resource.tf
+++ b/examples/resources/aquasec_host_assurance_policy/resource.tf
@@ -1,0 +1,90 @@
+//Example: Basic host assurance policy with essential settings
+resource "aquasec_host_assurance_policy" "basic" {
+  name               = "host_policy_basic"
+  description        = "Basic host assurance policy for production hosts"
+  application_scopes = ["Global"]
+
+  # Basic policy settings
+  enabled           = true
+  audit_on_failure  = true
+  block_failed      = true
+
+  # CIS Benchmarks
+  docker_cis_enabled    = true
+  kube_cis_enabled      = true
+  linux_cis_enabled     = true
+  windows_cis_enabled   = false
+
+  # Vulnerability scanning settings
+  cvss_severity_enabled       = true
+  cvss_severity              = "high"
+  cvss_severity_exclude_no_fix = false
+  maximum_score_enabled       = true
+  maximum_score              = 8
+  vulnerability_score_range   = [8, 10]
+
+  # Malware scanning
+  disallow_malware = true
+  malware_action   = "alert"
+  monitored_malware_paths = [
+    "/tmp",
+    "/var/tmp"
+  ]
+
+  # Auto scanning configuration
+  auto_scan_enabled      = true
+  auto_scan_configured   = true
+  auto_scan_time {
+    iteration_type = "daily"
+    time           = "2024-01-01T12:00:00Z"
+  }
+}
+
+// Example: Advanced host assurance policy with key settings
+resource "aquasec_host_assurance_policy" "advanced" {
+  
+  name               = "host_policy_advanced"
+  description        = "Advanced host assurance policy with key security controls"
+  application_scopes = ["Global"]
+
+  # Policy enforcement
+  enabled           = false
+  audit_on_failure  = true
+  block_failed      = true
+
+
+  # Vulnerability management
+  cvss_severity_enabled         = true
+  cvss_severity                = "critical"
+  maximum_score_enabled         = true
+  maximum_score                = 7
+  vulnerability_score_range     = [7, 10]
+
+  # CIS compliance checks
+  docker_cis_enabled    = true
+  kube_cis_enabled      = true
+  linux_cis_enabled     = true
+
+  # Malware scanning configuration
+  disallow_malware = true
+  malware_action   = "block"
+  monitored_malware_paths = [
+    "/tmp",
+    "/var/tmp"
+  ]
+
+  # Auto scanning configuration
+  auto_scan_enabled      = true
+  auto_scan_configured   = true
+  auto_scan_time {
+    iteration_type = "daily"
+    time           = "2024-01-01T00:00:00Z"
+  }
+
+  # Basic policy settings
+  policy_settings {
+    enforce          = true
+    warn             = true
+    warning_message  = "Host failed security compliance checks"
+  }
+}


### PR DESCRIPTION
#  Fix resource_host_assurance_policy

- Fix enabled field in schema:
  - Mark as Computed to handle API not returning the value
  - Remove Read function assignment to prevent state drift
  - Allow user-defined values while maintaining API compatibility

- Move enforce field to match API structure:
  - Relocate from top-level to nested policy_settings block
  - Align with API payload format

- Add resource.tf example file demonstrating host assurance policy usage

Resolves: SAAS-28325