### PR TITLE
Fix host assurance policy schema and add example

### DIFF
--- a/aquasec/resource_host_assurance_policy.go
+++ b/aquasec/resource_host_assurance_policy.go
@@ -480,10 +480,7 @@ func resourceHostAssurancePolicy() *schema.Resource {
 			"enabled": {
 				Type:     schema.TypeBool,
 				Optional: true,
-			},
-			"enforce": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Computed: true,
 			},
 			"enforce_after_days": {
 				Type:     schema.TypeInt,
@@ -992,7 +989,6 @@ func resourceHostAssurancePolicyRead(d *schema.ResourceData, m interface{}) erro
 	d.Set("cves_white_list", iap.CvesWhiteList)
 	d.Set("blacklist_permissions_enabled", iap.BlacklistPermissionsEnabled)
 	d.Set("blacklist_permissions", iap.BlacklistPermissions)
-	d.Set("enabled", iap.Enabled)
 	d.Set("enforce", iap.Enforce)
 	d.Set("enforce_after_days", iap.EnforceAfterDays)
 	d.Set("ignore_recently_published_vln", iap.IgnoreRecentlyPublishedVln)

--- a/aquasec/resource_host_assurance_policy_test.go
+++ b/aquasec/resource_host_assurance_policy_test.go
@@ -13,20 +13,75 @@ func TestAquasecHostAssurancePolicy(t *testing.T) {
 	t.Parallel()
 	description := "Created using Terraform"
 	name := acctest.RandomWithPrefix("terraform-test")
-	application_scopes := "Global"
+	resourceName := "aquasec_host_assurance_policy.terraformiap"
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
-		CheckDestroy: CheckDestroy("aquasec_host_assurance_policy.terraformiap"),
+		CheckDestroy: CheckDestroy(resourceName),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckHostAssurancePolicy(description, name, application_scopes),
+				Config: testAccCheckHostAssurancePolicyFull(name),
 				Check: resource.ComposeTestCheckFunc(
-					testAccCheckHostAssurancePolicyExists("aquasec_host_assurance_policy.terraformiap"),
+					testAccCheckHostAssurancePolicyExists(resourceName),
+					func(s *terraform.State) error {
+						if _, ok := s.RootModule().Resources[resourceName]; !ok {
+							return fmt.Errorf("Resource not found")
+						}
+						return nil
+					},
+					// Basic attributes
+					resource.TestCheckResourceAttr(resourceName, "name", name),
+					resource.TestCheckResourceAttr(resourceName, "description", description),
+					resource.TestCheckResourceAttr(resourceName, "application_scopes.0", "Global"),
+
+					// CVSS settings
+					resource.TestCheckResourceAttr(resourceName, "cvss_severity_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "cvss_severity", "critical"),
+					resource.TestCheckResourceAttr(resourceName, "cvss_severity_exclude_no_fix", "true"),
+
+					// Score settings
+					resource.TestCheckResourceAttr(resourceName, "maximum_score_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "maximum_score", "8"),
+					resource.TestCheckResourceAttr(resourceName, "control_exclude_no_fix", "true"),
+
+					// Malware settings
+					resource.TestCheckResourceAttr(resourceName, "disallow_malware", "true"),
+					resource.TestCheckResourceAttr(resourceName, "monitored_malware_paths.0", "/tmp"),
+					resource.TestCheckResourceAttr(resourceName, "scan_malware_in_archives", "true"),
+
+					// CIS benchmarks
+					resource.TestCheckResourceAttr(resourceName, "docker_cis_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "kube_cis_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "linux_cis_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "windows_cis_enabled", "true"),
+
+					// Enforcement settings
+					resource.TestCheckResourceAttr(resourceName, "audit_on_failure", "true"),
+					resource.TestCheckResourceAttr(resourceName, "fail_cicd", "true"),
+					resource.TestCheckResourceAttr(resourceName, "block_failed", "true"),
+					resource.TestCheckResourceAttr(resourceName, "enforce_excessive_permissions", "true"),
+
+					// Auto scan settings
+					resource.TestCheckResourceAttr(resourceName, "auto_scan_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scan_configured", "true"),
+					resource.TestCheckResourceAttr(resourceName, "auto_scan_time.0.iteration_type", "daily"),
+
+					// Scope settings
+					resource.TestCheckResourceAttr(resourceName, "scope.0.expression", "v1"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0.variables.0.attribute", "os.type"),
+					resource.TestCheckResourceAttr(resourceName, "scope.0.variables.0.value", "linux"),
+
+					// Labels
+					resource.TestCheckResourceAttr(resourceName, "required_labels_enabled", "true"),
+					resource.TestCheckResourceAttr(resourceName, "required_labels.0.key", "env"),
+					resource.TestCheckResourceAttr(resourceName, "required_labels.0.value", "prod"),
+
+					resource.TestCheckResourceAttr(resourceName, "maximum_score_exclude_no_fix", "true"),
 				),
 			},
 			{
-				ResourceName:      "aquasec_host_assurance_policy.terraformiap",
+				ResourceName:      resourceName,
 				ImportState:       true,
 				ImportStateVerify: true,
 			},
@@ -34,16 +89,74 @@ func TestAquasecHostAssurancePolicy(t *testing.T) {
 	})
 }
 
-func testAccCheckHostAssurancePolicy(description string, name string, application_scopes string) string {
+func testAccCheckHostAssurancePolicyFull(name string) string {
 	return fmt.Sprintf(`
-	resource "aquasec_host_assurance_policy" "terraformiap" {
-		description = "%s"
-		name = "%s"
-		application_scopes = [
-			"%s"
-		]
-	}`, description, name, application_scopes)
+resource "aquasec_host_assurance_policy" "terraformiap" {
+    name = "%s"
+    description = "Created using Terraform"
+    application_scopes = ["Global"]
 
+    cvss_severity_enabled = true
+    cvss_severity = "critical"
+    cvss_severity_exclude_no_fix = true
+    
+    maximum_score_enabled = true
+    maximum_score = 8
+    control_exclude_no_fix = true
+    
+    disallow_malware = true
+    monitored_malware_paths = ["/tmp"]
+    scan_malware_in_archives = true
+    
+    docker_cis_enabled = true
+    kube_cis_enabled = true
+    linux_cis_enabled = true
+    windows_cis_enabled = true
+    
+    audit_on_failure = true
+    fail_cicd = true
+    block_failed = true
+    enforce_excessive_permissions = true
+    
+    auto_scan_enabled = true
+    auto_scan_configured = true
+    auto_scan_time {
+        iteration_type = "daily"
+        time = "2024-01-01T00:00:00Z"
+    }
+    
+	scope {
+    expression = "v1"
+    variables {
+        attribute = "os.type"
+        value = "linux"
+    }
+	}
+    
+    required_labels_enabled = true
+    required_labels {
+        key = "env"
+        value = "prod"
+    }
+
+    vulnerability_exploitability = true
+    disallow_exploit_types = ["remote_exploit", "local_exploit"]
+    ignore_base_image_vln = false
+    ignored_sensitive_resources = ["/etc/passwd", "/etc/shadow"]
+    
+    scan_process_memory = true
+    scan_windows_registry = true
+    
+    policy_settings {
+        enforce = true
+        warn = true
+        warning_message = "Policy violation detected"
+        is_audit_checked = true
+    }
+
+    openshift_hardening_enabled = true
+	maximum_score_exclude_no_fix = true
+}`, name)
 }
 
 func testAccCheckHostAssurancePolicyExists(n string) resource.TestCheckFunc {

--- a/examples/resources/aquasec_host_assurance_policy/resource.tf
+++ b/examples/resources/aquasec_host_assurance_policy/resource.tf
@@ -1,0 +1,90 @@
+//Example: Basic host assurance policy with essential settings
+resource "aquasec_host_assurance_policy" "basic" {
+  name               = "host_policy_basic"
+  description        = "Basic host assurance policy for production hosts"
+  application_scopes = ["Global"]
+
+  # Basic policy settings
+  enabled           = true
+  audit_on_failure  = true
+  block_failed      = true
+
+  # CIS Benchmarks
+  docker_cis_enabled    = true
+  kube_cis_enabled      = true
+  linux_cis_enabled     = true
+  windows_cis_enabled   = false
+
+  # Vulnerability scanning settings
+  cvss_severity_enabled       = true
+  cvss_severity              = "high"
+  cvss_severity_exclude_no_fix = false
+  maximum_score_enabled       = true
+  maximum_score              = 8
+  vulnerability_score_range   = [8, 10]
+
+  # Malware scanning
+  disallow_malware = true
+  malware_action   = "alert"
+  monitored_malware_paths = [
+    "/tmp",
+    "/var/tmp"
+  ]
+
+  # Auto scanning configuration
+  auto_scan_enabled      = true
+  auto_scan_configured   = true
+  auto_scan_time {
+    iteration_type = "daily"
+    time           = "2024-01-01T12:00:00Z"
+  }
+}
+
+// Example: Advanced host assurance policy with key settings
+resource "aquasec_host_assurance_policy" "advanced" {
+  
+  name               = "host_policy_advanced"
+  description        = "Advanced host assurance policy with key security controls"
+  application_scopes = ["Global"]
+
+  # Policy enforcement
+  enabled           = false
+  audit_on_failure  = true
+  block_failed      = true
+
+
+  # Vulnerability management
+  cvss_severity_enabled         = true
+  cvss_severity                = "critical"
+  maximum_score_enabled         = true
+  maximum_score                = 7
+  vulnerability_score_range     = [7, 10]
+
+  # CIS compliance checks
+  docker_cis_enabled    = true
+  kube_cis_enabled      = true
+  linux_cis_enabled     = true
+
+  # Malware scanning configuration
+  disallow_malware = true
+  malware_action   = "block"
+  monitored_malware_paths = [
+    "/tmp",
+    "/var/tmp"
+  ]
+
+  # Auto scanning configuration
+  auto_scan_enabled      = true
+  auto_scan_configured   = true
+  auto_scan_time {
+    iteration_type = "daily"
+    time           = "2024-01-01T00:00:00Z"
+  }
+
+  # Basic policy settings
+  policy_settings {
+    enforce          = true
+    warn             = true
+    warning_message  = "Host failed security compliance checks"
+  }
+}


### PR DESCRIPTION
- Fix enabled field in schema:
  - Mark as Computed to handle API not returning the value
  - Remove Read function assignment to prevent state drift
  - Allow user-defined values while maintaining API compatibility

- Move enforce field to match API structure:
  - Relocate from top-level to nested policy_settings block
  - Align with API payload format

- Add resource.tf example file demonstrating host assurance policy usage
- Improve test coverage

Resolves: SAAS-28325