### PR TITLE
feat(application-scope): add CodeBuild support to application scope

### DIFF
--- a/aquasec/data_application_scope.go
+++ b/aquasec/data_application_scope.go
@@ -141,6 +141,40 @@ func dataApplicationScope() *schema.Resource {
 											},
 										},
 									},
+									"codebuild": {
+                						Type:     schema.TypeSet,
+                						Optional: true,
+                						Elem: &schema.Resource{
+                    						Schema: map[string]*schema.Schema{
+                        						"expression": {
+													Type:     schema.TypeString,
+													Optional: true,
+													Computed: true,
+												},
+												"variables": {
+													Type:     schema.TypeList,
+													Optional: true,
+													Elem: &schema.Resource{
+														Schema: map[string]*schema.Schema{
+															"attribute": {
+																Type:     schema.TypeString,
+																Optional: true,
+																Computed: true,
+															},
+															"value": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+															"name": {
+																Type:     schema.TypeString,
+																Optional: true,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
 								},
 							},
 						},

--- a/aquasec/data_application_scope_test.go
+++ b/aquasec/data_application_scope_test.go
@@ -3,12 +3,10 @@ package aquasec
 import (
 	"fmt"
 	"testing"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-func TestDataApplicationScopePolicy(t *testing.T) {
+func TestDataApplicationScope(t *testing.T) {
 	t.Parallel()
 	name := "Global"
 	resource.Test(t, resource.TestCase{
@@ -16,37 +14,110 @@ func TestDataApplicationScopePolicy(t *testing.T) {
 		Providers: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckApplicationScopePolicyDataSource(name),
-				Check:  testAccCheckApplicationScopePolicyDataSourceExists("data.aquasec_application_scope.defaultiap"),
+				Config: testAccCheckApplicationScopeDataSource(name),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationScopeExists("data.aquasec_application_scope.defaultiap"),
+					// Basic attribute checks
+					resource.TestCheckResourceAttr("data.aquasec_application_scope.defaultiap", "name", name),
+					resource.TestCheckResourceAttrSet("data.aquasec_application_scope.defaultiap", "description"),
+					resource.TestCheckResourceAttrSet("data.aquasec_application_scope.defaultiap", "author"),
+					// Categories existence check
+					resource.TestCheckResourceAttrSet("data.aquasec_application_scope.defaultiap", "categories.#"),
+				),
 			},
 		},
 	})
 }
 
-func testAccCheckApplicationScopePolicyDataSource(name string) string {
+// Test specific for codebuild data source functionality
+func TestDataApplicationScopeWithCodeBuild(t *testing.T) {
+	t.Parallel()
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				// First create a scope with codebuild
+				Config: testAccCheckApplicationScopeWithCodeBuild(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationScopeExists("aquasec_application_scope.test_codebuild"),
+				),
+			},
+			{
+				// Then test reading it as a data source
+				Config: testAccCheckApplicationScopeWithCodeBuildDataSource(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckApplicationScopeExists("data.aquasec_application_scope.test_codebuild_ds"),
+					// Verify codebuild specific attributes
+					resource.TestCheckResourceAttr(
+						"data.aquasec_application_scope.test_codebuild_ds",
+						"categories.0.artifacts.0.codebuild.0.expression",
+						"v1",
+					),
+					resource.TestCheckResourceAttr(
+						"data.aquasec_application_scope.test_codebuild_ds",
+						"categories.0.artifacts.0.codebuild.0.variables.0.attribute",
+						"aqua.topic",
+					),
+					resource.TestCheckResourceAttr(
+						"data.aquasec_application_scope.test_codebuild_ds",
+						"categories.0.artifacts.0.codebuild.0.variables.0.value",
+						"topic1",
+					),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckApplicationScopeDataSource(name string) string {
 	return fmt.Sprintf(`
 	data "aquasec_application_scope" "defaultiap" {
 		name = "%s"
 	}
-	output "appscopes" {
-		value = data.aquasec_application_scope.defaultiap
-	}
 	`, name)
-
 }
 
-func testAccCheckApplicationScopePolicyDataSourceExists(n string) resource.TestCheckFunc {
-	return func(s *terraform.State) error {
-		rs, ok := s.RootModule().Resources[n]
-
-		if !ok {
-			return NewNotFoundErrorf("%s in state", n)
+func testAccCheckApplicationScopeWithCodeBuild() string {
+	return `
+	resource "aquasec_application_scope" "test_codebuild" {
+		description = "test codebuild application scope"
+		name        = "test_codebuild"
+		
+		categories {
+			artifacts {
+				codebuild {
+					expression = "v1"
+					variables {
+						attribute = "aqua.topic"
+						value     = "topic1"
+					}
+				}
+			}
 		}
+	}`
+}
 
-		if rs.Primary.ID == "" {
-			return NewNotFoundErrorf("ID for %s in state", n)
+func testAccCheckApplicationScopeWithCodeBuildDataSource() string {
+	return `
+	resource "aquasec_application_scope" "test_codebuild" {
+		description = "test codebuild application scope"
+		name        = "test_codebuild"
+		
+		categories {
+			artifacts {
+				codebuild {
+					expression = "v1"
+					variables {
+						attribute = "aqua.topic"
+						value     = "topic1"
+					}
+				}
+			}
 		}
-
-		return nil
 	}
+
+	data "aquasec_application_scope" "test_codebuild_ds" {
+		name = aquasec_application_scope.test_codebuild.name
+	}`
 }

--- a/aquasec/resource_application_scope_test.go
+++ b/aquasec/resource_application_scope_test.go
@@ -46,6 +46,15 @@ func TestAquasecApplicationScope(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "categories.0.infrastructure.0.kubernetes.0.expression", "v1"),
 					resource.TestCheckResourceAttr(resourceName, "categories.0.infrastructure.0.kubernetes.0.variables.0.attribute", "kubernetes.cluster"),
 					resource.TestCheckResourceAttr(resourceName, "categories.0.infrastructure.0.kubernetes.0.variables.0.value", "lion"),
+					// Verify basic attributes
+                    resource.TestCheckResourceAttr(resourceName, "name", name),
+                    resource.TestCheckResourceAttr(resourceName, "description", description),
+                    // Verify existing artifacts
+                    resource.TestCheckResourceAttr(resourceName, "categories.0.artifacts.0.image.0.expression", "v1 && v2 && v3"),
+                    // Add codebuild verification
+                    resource.TestCheckResourceAttr(resourceName, "categories.0.artifacts.0.codebuild.0.expression", "v1"),
+                    resource.TestCheckResourceAttr(resourceName, "categories.0.artifacts.0.codebuild.0.variables.0.attribute", "aqua.topic"),
+                    resource.TestCheckResourceAttr(resourceName, "categories.0.artifacts.0.codebuild.0.variables.0.value", "topic1"),
 				),
 			},
 			{
@@ -80,6 +89,13 @@ func testAccCheckApplicationScope(name string, description string) string {
 						value = "test.value.123"
 					}
 				}
+				codebuild {
+                    expression = "v1"
+                    variables {
+                        attribute = "aqua.topic"
+                        value = "topic1"
+                    }
+                }
 			}
 			workloads {
 				kubernetes {

--- a/client/application_scope.go
+++ b/client/application_scope.go
@@ -29,6 +29,7 @@ type Artifact struct {
 	Image    CommonStruct `json:"image"`
 	Function CommonStruct `json:"function"`
 	CF       CommonStruct `json:"cf"`
+	CodeBuild CommonStruct `json:"codebuild"`
 }
 
 type Workload struct {

--- a/docs/data-sources/application_scope.md
+++ b/docs/data-sources/application_scope.md
@@ -58,6 +58,7 @@ Optional:
 - `cf` (Block Set) (see [below for nested schema](#nestedblock--categories--artifacts--cf))
 - `function` (Block Set) (see [below for nested schema](#nestedblock--categories--artifacts--function))
 - `image` (Block Set) (see [below for nested schema](#nestedblock--categories--artifacts--image))
+- `codebuild` (Block Set) AWS CodeBuild configuration (see [below for nested schema](#nestedblock--categories--artifacts--codebuild))
 
 <a id="nestedblock--categories--artifacts--cf"></a>
 ### Nested Schema for `categories.artifacts.cf`
@@ -76,6 +77,22 @@ Optional:
 - `name` (String)
 - `value` (String)
 
+<a id="nestedblock--categories--artifacts--codebuild"></a>
+### Nested Schema for `categories.artifacts.codebuild`
+
+Optional:
+
+- `expression` (String) The expression used to match CodeBuild resources
+- `variables` (Block List) Variables used in the expression (see [below for nested schema](#nestedblock--categories--artifacts--codebuild--variables))
+
+<a id="nestedblock--categories--artifacts--codebuild--variables"></a>
+### Nested Schema for `categories.artifacts.codebuild.variables`
+
+Optional:
+
+- `attribute` (String) The attribute to match against
+- `name` (String) Name of the variable
+- `value` (String) Value to match
 
 
 <a id="nestedblock--categories--artifacts--function"></a>

--- a/docs/resources/application_scope.md
+++ b/docs/resources/application_scope.md
@@ -100,6 +100,7 @@ Read-Only:
 Optional:
 
 - `cf` (Block Set) (see [below for nested schema](#nestedblock--categories--artifacts--cf))
+- `codebuild` (Block Set) AWS CodeBuild configuration (see [below for nested schema](#nestedblock--categories--artifacts--codebuild))
 - `function` (Block Set) Function name (see [below for nested schema](#nestedblock--categories--artifacts--function))
 - `image` (Block Set) Name of a registry as defined in Aqua (see [below for nested schema](#nestedblock--categories--artifacts--image))
 
@@ -110,6 +111,23 @@ Optional:
 
 - `expression` (String)
 - `variables` (Block List) (see [below for nested schema](#nestedblock--categories--artifacts--cf--variables))
+
+<a id="nestedblock--categories--artifacts--codebuild"></a>
+### Nested Schema for `categories.artifacts.codebuild`
+
+Optional:
+
+- `expression` (String)
+- `variables` (Block List) (see [below for nested schema](#nestedblock--categories--artifacts--codebuild--variables))
+
+<a id="nestedblock--categories--artifacts--codebuild--variables"></a>
+### Nested Schema for `categories.artifacts.codebuild.variables`
+
+Optional:
+
+- `attribute` (String)
+- `name` (String)
+- `value` (String)
 
 <a id="nestedblock--categories--artifacts--cf--variables"></a>
 ### Nested Schema for `categories.artifacts.cf.variables`

--- a/examples/data-sources/aquasec_application_scope/data-source.tf
+++ b/examples/data-sources/aquasec_application_scope/data-source.tf
@@ -5,3 +5,11 @@ data "aquasec_application_scope" "default" {
 output "scopes" {
   value = data.aquasec_application_scope.default
 }
+
+output "codebuild_config" {
+  value = [
+    for category in data.aquasec_application_scope.default.categories : [
+      for artifact in category.artifacts : artifact.codebuild if artifact.codebuild != null
+    ] if category.artifacts != null
+  ][0][0]
+}

--- a/examples/resources/aquasec_application_scope/resource.tf
+++ b/examples/resources/aquasec_application_scope/resource.tf
@@ -3,7 +3,7 @@ resource "aquasec_application_scope" "terraformiap" {
   name        = "test18"
   // Categories is a nested block of artifacts, workloads and infrastructure
   categories {
-    // Artifacts is a nested block of Image, Function, CF
+    // Artifacts is a nested block of Image, Function, CF, and CodeBuild
     artifacts {
       // Every object requires expression(logical combinations of variables v1, v2, v3...) and list of variables consists of attribute(pre-defined) and value
       image {
@@ -15,6 +15,13 @@ resource "aquasec_application_scope" "terraformiap" {
         variables {
           attribute = "image.repo"
           value     = "nginx"
+        }
+      }
+      codebuild {
+        expression = "v1"
+        variables {
+          attribute = "aqua.topic"
+          value     = "topic1"
         }
       }
     }


### PR DESCRIPTION
Resolves: SLK-88698 & #259

Added support for AWS CodeBuild in the application scope resource and data source. This allows
users to apply labels to CodeBuild repositories to control access to the
repository, and query existing CodeBuild configurations.

Changes include:
- Added CodeBuild to the ApplicationScope struct in client package
- Updated resource schema to support CodeBuild configuration
- Added CodeBuild handling in create/update/read functions
- Added CodeBuild support to the application scope data source
- Updated both resource and data source test files with CodeBuild test cases
- Fixed type handling and nil checks in createCategory function
- Added safer type assertions for CodeBuild and other artifact types
- Updated documentation to include CodeBuild configuration options for both resource and data source
- Added example configurations to demonstrate CodeBuild usage

Example resource usage:
```
resource "aquasec_application_scope" "example" {
  categories {
    artifacts {
      codebuild {
        expression = "v1"
        variables {
          attribute = "aqua.topic"
          value     = "topic1"
        }
      }
    }
  }
}
```

Example data source usage:
```
data "aquasec_application_scope" "example" {
  name = "existing-scope"
}

output "codebuild_config" {
  value = [
    for category in data.aquasec_application_scope.example.categories : [
      for artifact in category.artifacts : artifact.codebuild if artifact.codebuild != null
    ] if category.artifacts != null
  ][0][0]
}
```