### PR TITLE
Refactor aquasec_role_mapping_sass (resource and datasource), Refactor sso.go

### DIFF
--- a/aquasec/data_role_mapping_saas_test.go
+++ b/aquasec/data_role_mapping_saas_test.go
@@ -1,0 +1,48 @@
+package aquasec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAquasecRolesMappingSaasDatasource(t *testing.T) {
+	if !isSaasEnv() {
+		t.Skip("Skipping SaaS roles mapping data source test - not a SaaS environment")
+	}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccCheckAquasecRolesMappingSaasBasicConfig(),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckAquasecRolesMappingSaasExists("data.aquasec_roles_mapping_saas.test"),
+					resource.TestCheckResourceAttrSet("data.aquasec_roles_mapping_saas.test", "roles_mapping.#"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAquasecRolesMappingSaasBasicConfig() string {
+	return `
+	data "aquasec_roles_mapping_saas" "test" {}
+	`
+}
+
+func testAccCheckAquasecRolesMappingSaasExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Not found: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("No ID is set for %s", n)
+		}
+		return nil
+	}
+}

--- a/aquasec/data_role_mapping_sass.go
+++ b/aquasec/data_role_mapping_sass.go
@@ -60,6 +60,7 @@ func dataRolesMappingSaasRead(ctx context.Context, d *schema.ResourceData, m int
 	} else {
 		return diag.FromErr(err)
 	}
+	d.SetId("aquasec_roles_mapping_saas_list")
 	return nil
 }
 

--- a/aquasec/resource_role.go
+++ b/aquasec/resource_role.go
@@ -87,7 +87,7 @@ func resourceRoleRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	d.Set("name", r.Name)
+	d.Set("role_name", r.Name)
 	d.Set("updated_at", r.UpdatedAt)
 	d.Set("author", r.Author)
 

--- a/aquasec/resource_role_mapping_saas.go
+++ b/aquasec/resource_role_mapping_saas.go
@@ -53,19 +53,33 @@ func resourceRoleMappingSaasRead(ctx context.Context, d *schema.ResourceData, m 
 	ac := m.(*client.Client)
 
 	r, err := ac.GetRoleMappingSaas(d.Id())
-	if err == nil {
-		d.Set("role_mapping_id", r.Id)
-		d.Set("created", r.Created)
-		d.Set("account_id", r.AccountId)
-	} else {
+	if err != nil {
 		if strings.Contains(err.Error(), "404") {
 			d.SetId("")
-		} else {
-			return diag.FromErr(err)
+			return nil
 		}
+		return diag.FromErr(err)
 	}
+
+	if err := d.Set("role_mapping_id", r.Id); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("created", r.Created); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("account_id", r.AccountId); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("csp_role", r.CspRole); err != nil {
+		return diag.FromErr(err)
+	}
+	if err := d.Set("saml_groups", r.SamlGroups); err != nil {
+		return diag.FromErr(err)
+	}
+
 	return nil
 }
+
 
 func resourceRoleMappingSaasCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*client.Client)

--- a/aquasec/resource_role_mapping_saas_test.go
+++ b/aquasec/resource_role_mapping_saas_test.go
@@ -1,0 +1,103 @@
+package aquasec
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aquasecurity/terraform-provider-aquasec/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/acctest"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+const (
+	testRoleMappingSaasResourceName = "aquasec_role_mapping_saas.test"
+)
+
+func TestAccAquasecRoleMappingSaas_basic(t *testing.T) {
+	if !isSaasEnv() {
+		t.Skip("Skipping role mapping SaaS test - not a SaaS environment")
+	}
+
+	roleName := acctest.RandomWithPrefix("tf-role")
+	permSetName := acctest.RandomWithPrefix("tf-pset")
+	samlGroups := []string{"DevTeam", "SecTeam"}
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckRoleMappingSaasDestroy,
+		Steps: []resource.TestStep{
+			{
+				Config: testAccRoleMappingSaasConfig(permSetName, roleName, samlGroups),
+				Check: resource.ComposeTestCheckFunc(
+					testAccCheckRoleMappingSaasExists(testRoleMappingSaasResourceName),
+					resource.TestCheckResourceAttr(testRoleMappingSaasResourceName, "csp_role", roleName),
+					resource.TestCheckResourceAttr(testRoleMappingSaasResourceName, "saml_groups.#", "2"),
+				),
+			},
+			{
+				ResourceName:      testRoleMappingSaasResourceName,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func testAccRoleMappingSaasConfig(permSetName, roleName string, groups []string) string {
+	groupsStr := ""
+	for _, g := range groups {
+		groupsStr += fmt.Sprintf("\"%s\", ", g)
+	}
+	groupsStr = groupsStr[:len(groupsStr)-2]
+
+	return fmt.Sprintf(`
+resource "aquasec_permission_set_saas" "ps" {
+  name        = "%s"
+  description = "TF-generated permission set"
+  actions     = ["account_mgmt.groups.read"]
+}
+
+resource "aquasec_role" "r" {
+  role_name   = "%s"
+  description = "TF-generated role"
+  permission  = aquasec_permission_set_saas.ps.name
+  scopes      = ["Global"]
+}
+
+resource "aquasec_role_mapping_saas" "test" {
+  saml_groups = [%s]
+  csp_role    = aquasec_role.r.role_name
+}
+`, permSetName, roleName, groupsStr)
+}
+
+func testAccCheckRoleMappingSaasExists(n string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[n]
+		if !ok {
+			return fmt.Errorf("Resource not found in state: %s", n)
+		}
+		if rs.Primary.ID == "" {
+			return fmt.Errorf("ID not set for resource: %s", n)
+		}
+		cli := testAccProvider.Meta().(*client.Client)
+		_, err := cli.GetRoleMappingSaas(rs.Primary.ID)
+		return err
+	}
+}
+
+func testAccCheckRoleMappingSaasDestroy(s *terraform.State) error {
+	cli := testAccProvider.Meta().(*client.Client)
+	for _, rs := range s.RootModule().Resources {
+		if rs.Type != "aquasec_role_mapping_saas" {
+			continue
+		}
+		_, err := cli.GetRoleMappingSaas(rs.Primary.ID)
+		if err == nil {
+			return fmt.Errorf("role mapping %q still exists", rs.Primary.ID)
+		}
+	}
+	return nil
+}

--- a/client/role_mapping_saas.go
+++ b/client/role_mapping_saas.go
@@ -1,0 +1,169 @@
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/pkg/errors"
+
+)
+
+type RoleMappingSaas struct {
+	CspRole    string   `json:"csp_role"`
+	SamlGroups []string `json:"saml_groups"`
+	Id         int      `json:"id"`
+	Created    string   `json:"created"`
+	AccountId  int      `json:"account_id"`
+}
+
+type RoleMappingSaasList struct {
+	Items []RoleMappingSaas `json:"data"`
+}
+
+type RoleMappingSaasResponse struct {
+	RoleMappingSaas RoleMappingSaas `json:"data"`
+}
+
+const roleMappingBasePath = "/api/cspm/v2/samlmappings"
+
+func (cli *Client) GetRoleMappingSaas(id string) (*RoleMappingSaas, error) {
+	if cli.clientType != Saas && cli.clientType != SaasDev {
+		return nil, fmt.Errorf("GetRoleMappingSaas is supported only in Aqua SaaS environment")
+	}
+
+	if err := cli.limiter.Wait(context.Background()); err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s%s/%s", cli.saasUrl, roleMappingBasePath, id)
+	resp, body, errs := cli.gorequest.Clone().Get(url).
+		Set("Authorization", fmt.Sprintf(authHeaderFormat, cli.token)).End()
+
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("failed GET %s: %v", url, errs)
+	}
+	if resp.StatusCode != statusOK {
+		return nil, fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, body)
+	}
+
+	var result RoleMappingSaasResponse
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal RoleMappingSaas response")
+	}
+	return &result.RoleMappingSaas, nil
+}
+
+func (cli *Client) GetRolesMappingSaas() (*RoleMappingSaasList, error) {
+	if cli.clientType != Saas && cli.clientType != SaasDev {
+		return nil, fmt.Errorf("GetRolesMappingSaas is supported only in Aqua SaaS environment")
+	}
+
+	if err := cli.limiter.Wait(context.Background()); err != nil {
+		return nil, err
+	}
+
+	url := fmt.Sprintf("%s%s", cli.saasUrl, roleMappingBasePath)
+	resp, body, errs := cli.gorequest.Clone().Get(url).
+		Set("Authorization", fmt.Sprintf(authHeaderFormat, cli.token)).End()
+
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("failed GET %s: %v", url, errs)
+	}
+	if resp.StatusCode != statusOK {
+		return nil, fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, body)
+	}
+
+	var result RoleMappingSaasList
+	if err := json.Unmarshal([]byte(body), &result); err != nil {
+		return nil, errors.Wrap(err, "failed to unmarshal RoleMappingSaas list")
+	}
+	return &result, nil
+}
+
+func (cli *Client) CreateRoleMappingSaas(saas *RoleMappingSaas) error {
+	if cli.clientType != Saas && cli.clientType != SaasDev {
+		return fmt.Errorf("CreateRoleMappingSaas is supported only in Aqua SaaS environment")
+	}
+
+	if err := cli.limiter.Wait(context.Background()); err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s%s", cli.saasUrl, roleMappingBasePath)
+	saasPayload := map[string]interface{}{
+		"csp_role":     saas.CspRole,
+		"saml_groups": saas.SamlGroups,
+	}
+	payload, _ := json.Marshal(saasPayload)
+
+	resp, body, errs := cli.gorequest.Clone().Post(url).
+		Set("Authorization", fmt.Sprintf(authHeaderFormat, cli.token)).
+		Send(string(payload)).End()
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed POST %s: %v", url, errs)
+	}
+	if resp.StatusCode != statusCreated {
+		return fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, body)
+	}
+
+	var response RoleMappingSaasResponse
+	if err := json.Unmarshal([]byte(body), &response); err != nil {
+		return errors.Wrap(err, "failed to unmarshal response after creation")
+	}
+	saas.Id = response.RoleMappingSaas.Id
+	saas.Created = response.RoleMappingSaas.Created
+	saas.AccountId = response.RoleMappingSaas.AccountId
+	return nil
+}
+
+func (cli *Client) UpdateRoleMappingSaas(saas *RoleMappingSaas, id string) error {
+	if cli.clientType != Saas && cli.clientType != SaasDev {
+		return fmt.Errorf("UpdateRoleMappingSaas is supported only in Aqua SaaS environment")
+	}
+
+	if err := cli.limiter.Wait(context.Background()); err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s%s/%s", cli.saasUrl, roleMappingBasePath, id)
+	payloadMap := map[string]interface{}{
+		"saml_groups": saas.SamlGroups,
+	}
+	payload, _ := json.Marshal(payloadMap)
+
+	resp, body, errs := cli.gorequest.Clone().Put(url).
+		Set("Authorization", fmt.Sprintf(authHeaderFormat, cli.token)).
+		Send(string(payload)).End()
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed PUT %s: %v", url, errs)
+	}
+	if resp.StatusCode != statusNoContent {
+		return fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, body)
+	}
+	return nil
+}
+
+func (cli *Client) DeleteRoleMappingSaas(id string) error {
+	if cli.clientType != Saas && cli.clientType != SaasDev {
+		return fmt.Errorf("DeleteRoleMappingSaas is supported only in Aqua SaaS environment")
+	}
+
+	if err := cli.limiter.Wait(context.Background()); err != nil {
+		return err
+	}
+
+	url := fmt.Sprintf("%s%s/%s", cli.saasUrl, roleMappingBasePath, id)
+	resp, body, errs := cli.gorequest.Clone().Delete(url).
+		Set("Authorization", fmt.Sprintf(authHeaderFormat, cli.token)).End()
+
+	if len(errs) > 0 {
+		return fmt.Errorf("failed DELETE %s: %v", url, errs)
+	}
+	if resp.StatusCode != statusOK {
+		return fmt.Errorf("unexpected status code: %d, response: %s", resp.StatusCode, body)
+	}
+	return nil
+}

--- a/docs/resources/role_mapping_saas.md
+++ b/docs/resources/role_mapping_saas.md
@@ -8,14 +8,20 @@ description: |-
 
 # aquasec_role_mapping_saas (Resource)
 
+Role mappings in Aqua SaaS allow you to associate SAML group names with specific roles defined in the Aqua platform. This enables fine-grained access control via your identity provider (IdP).
 
+The Terraform resource aquasec_role_mapping_saas enables you to define these mappings as code.
+
+Prerequisites: permission_set_saas (`aquasec_permission_set_saas`), role (`aquasec_role`)
+
+---
 
 ## Example Usage
 
 ```terraform
 resource "aquasec_role_mapping_saas" "roles_mapping_saas" {
   saml_groups = ["group1", "group2"]
-  csp_role    = "Administrator"
+  csp_role    = "Administrator" # Must match an existing role
 }
 
 output "roles_mapping_saas" {

--- a/examples/resources/aquasec_role_mapping_saas/resource.tf
+++ b/examples/resources/aquasec_role_mapping_saas/resource.tf
@@ -1,8 +1,23 @@
-resource "aquasec_role_mapping_saas" "roles_mapping_saas" {
-  saml_groups = ["group1", "group2"]
-  csp_role    = "Administrator"
+# Create a Permission Set
+resource "aquasec_permission_set_saas" "example" {
+  name        = "example-permissions"
+  description = "Permission set for Example team"
+  actions     = [
+    "account_mgmt.groups.read",
+    "cspm.cloud_accounts.read",
+  ]
 }
 
-output "roles_mapping_saas" {
-  value = aquasec_role_mapping_saas.roles_mapping_saas
+# Create a Role with the permission set and application scope(s)
+resource "aquasec_role" "example" {
+  role_name   = "ExampleTeam"
+  description = "Role for ExampleTeam with limited access"
+  permission  = aquasec_permission_set_saas.example.name
+  scopes      = ["Global"]
+}
+
+# Map SAML groups to the Role
+resource "aquasec_role_mapping_saas" "example" {
+  saml_groups = ["Engineering", "Security"]
+  csp_role    = aquasec_role.example.role_name
 }


### PR DESCRIPTION
feat: add SaaS role mapping resource & data source + edge-compatible client + tests & cleanup

This commit introduces support for managing `aquasec_role_mapping_saas` as a Terraform resource and data source. It includes full CRUD support, import capabilities, and acceptance tests. It also refactors and relocates the client implementation to use the correct SaaS Edge-compatible API and restructures the provider code for clarity and correctness.

---

### 🔧 Resource: `aquasec_role_mapping_saas`

- Supports attributes:
  - `saml_groups`
  - `csp_role`
- Full CRUD and `terraform import` support
- Created: `resource_role_mapping_saas.go`

---

### 🧠 Read Function Fix

- Fixed `Read()` to correctly populate all state fields:
  - `csp_role`, `saml_groups`, `account_id`, `created`, `role_mapping_id`
- Prevented import drift
- Allows `ImportStateVerify` to pass cleanly in acceptance tests

---

### 🧪 Resource Acceptance Tests

- Added: `resource_role_mapping_saas_test.go`
- `TestAccAquasecRoleMappingSaas_basic` validates:
  - Resource creation with dynamic permission set + role
  - State matches remote data post-import
  - Clean deletion

---

### 🔎 Data Source: `aquasec_roles_mapping_saas`

- Added `data_role_mapping_saas.go` and new test:
  - `data_role_mapping_saas_test.go`
- Test ensures:
  - Data source loads
  - Returns a list of role mappings
  - Sets ID and expected attributes

---

### 🧹 Bug Fix in `aquasec_role`

- Fixed panic during `terraform apply`:
  - Changed `d.Set("name", ...)` → `d.Set("role_name", ...)`
  - Matches defined schema attribute

---

### 🔄 Role Mapping Client Refactor & Edge API Migration

- ✅ Moved role mapping client logic out of `sso.go` → `role_mapping_saas.go`:
  - New methods: `GetRoleMappingSaas`, `Create`, `Update`, `Delete`, `GetAll`
  - Structs: `RoleMappingSaas`, `RoleMappingSaasResponse`, etc.
- ✅ Updated all client methods to use the **SaaS Edge Server**:
  - Replaced deprecated Cloudsploit path:
    - ❌ `/v2/samlmappings` (under `cli.tokenUrl`)
    - ✅ `/api/cspm/v2/samlmappings` (under `cli.saasUrl`)
- Ensures production compatibility for modern SaaS tenants
- Retains versioned endpoint format aligned with other SaaS APIs

---

### 🧼 SSO Client Cleanup in `sso.go`

- Removed unrelated role mapping logic
- Simplified SSO methods:
  - `GetSSO`, `CreateSSO`, `UpdateSSO`, `DeleteSSO`
- Removed unnecessary switch blocks and duplicate logic
- Added stricter `clientType` validation per environment

---

### 📖 Documentation & Examples

- Updated: `docs/resources/role_mapping_saas.md`:
  - Usage clarified
  - Lists dependency on role + permission set
- Updated: `examples/resources/aquasec_role_mapping_saas/resource.tf`
  - Now includes end-to-end config:
    - permission set → role → mapping

---

This commit ensures `aquasec_role_mapping_saas` is **production-ready**, fully tested, and aligned with Aqua's modern Edge APIs. It improves modularity, correctness, and long-term maintainability across both resource and data source implementations.
