### PR TITLE
bug: fix for error creating integration registry

### DIFF
--- a/client/registries.go
+++ b/client/registries.go
@@ -11,37 +11,39 @@ import (
 
 // Registry defines a registry
 type Registry struct {
-	Name                       string    `json:"name"`
-	Type                       string    `json:"type"` // [HUB, V1/V2, ENGINE, AWS, GCR]
-	Description                string    `json:"description"`
-	Author                     string    `json:"author"`
-	Lastupdate                 int       `json:"lastupdate"`
-	URL                        string    `json:"url"`
-	Username                   string    `json:"username"`
-	Password                   string    `json:"password"`
-	ImageCreationDateCondition string    `json:"image_creation_date_condition"`
-	AdvancedSettingsCleanup    bool      `json:"advanced_settings_cleanup"`
-	AutoPull                   bool      `json:"auto_pull"`
-	AutoPullTime               string    `json:"auto_pull_time"`
-	AutoPullMax                int       `json:"auto_pull_max"`
-	RegistryScanTimeout        int       `json:"registry_scan_timeout"`
-	AutoPullInterval           int       `json:"auto_pull_interval"`
-	AutoCleanUp                bool      `json:"auto_cleanup"`
-	AlwaysPullPatterns         []string  `json:"always_pull_patterns"`
-	PullRepoPatternsExcluded   []string  `json:"pull_repo_patterns_excluded"`
-	AutoPullRescan             bool      `json:"auto_pull_rescan"`
-	Prefixes                   []string  `json:"prefixes"`
-	Webhook                    Webhook   `json:"webhook"`
-	PullImageAge               string    `json:"pull_image_age"`
-	PullImageCount             int       `json:"pull_image_count"`
-	PullImageTagPattern        []string  `json:"pull_image_tag_pattern"`
-	ScannerType                string    `json:"scanner_type"`
-	ScannerName                []string  `json:"scanner_name,omitempty"`
-	ScannerNameAdded           []string  `json:"scanner_name_added,omitempty"`
-	ScannerNameRemoved         []string  `json:"scanner_name_removed,omitempty"`
-	ExistingScanners           []string  `json:"existsing_scanners,omitempty"`
-	Options                    []Options `json:"options"`
-	DefaultPrefix              string    `json:"default_prefix"`
+	Name                       string       `json:"name"`
+	Type                       string       `json:"type"` // [HUB, V1/V2, ENGINE, AWS, GCR]
+	Description                string       `json:"description"`
+	Author                     string       `json:"author"`
+	Lastupdate                 int          `json:"lastupdate"`
+	URL                        string       `json:"url"`
+	Username                   string       `json:"username"`
+	Password                   string       `json:"password"`
+	ImageCreationDateCondition string       `json:"image_creation_date_condition"`
+	AdvancedSettingsCleanup    bool         `json:"advanced_settings_cleanup"`
+	AutoPull                   bool         `json:"auto_pull"`
+	AutoPullTime               string       `json:"auto_pull_time"`
+	AutoPullMax                int          `json:"auto_pull_max"`
+	RegistryScanTimeout        int          `json:"registry_scan_timeout"`
+	AutoPullInterval           int          `json:"auto_pull_interval"`
+	AutoCleanUp                bool         `json:"auto_cleanup"`
+	AlwaysPullPatterns         []string     `json:"always_pull_patterns"`
+	PullRepoPatternsExcluded   []string     `json:"pull_repo_patterns_excluded"`
+	AutoPullRescan             bool         `json:"auto_pull_rescan"`
+	Prefixes                   []string     `json:"prefixes"`
+	Webhook                    Webhook      `json:"webhook"`
+	PullImageAge               string       `json:"pull_image_age"`
+	PullImageCount             int          `json:"pull_image_count"`
+	PullImageTagPattern        []string     `json:"pull_image_tag_pattern"`
+	ScannerType                string       `json:"scanner_type,omitempty"`
+	ScannerGroupName           string       `json:"scanner_group_name,omitempty"`
+	ScannerName                []string     `json:"scanner_name,omitempty"`
+	ScannerNameAdded           []string     `json:"scanner_name_added,omitempty"`
+	ScannerNameRemoved         []string     `json:"scanner_name_removed,omitempty"`
+	ExistingScanners           []string     `json:"existsing_scanners,omitempty"`
+	Options                    []Options    `json:"options"`
+	DefaultPrefix              string       `json:"default_prefix"`
+	AutoScanTime               AutoScanTime `json:"auto_scan_time"`
 	//Architecture               string        `json:"architecture"`
 	//ICRAccountId               string        `json:"icr_account_id"`
 	//ACRConnectionType          string        `json:"acr_connection_type"`
@@ -58,6 +60,14 @@ type Webhook struct {
 type Options struct {
 	Option string `json:"option"`
 	Value  string `json:"value"`
+}
+
+type AutoScanTime struct {
+	AutoPullDay   int      `json:"auto_pull_day,omitempty"`
+	Iteration     int      `json:"iteration,omitempty"`
+	IterationType string   `json:"iteration_type,omitempty"`
+	Time          string   `json:"time,omitempty"`
+	WeekDays      []string `json:"week_days,omitempty"`
 }
 
 func (cli *Client) GetRegistry(name string) (*Registry, error) {

--- a/docs/resources/integration_registry.md
+++ b/docs/resources/integration_registry.md
@@ -62,6 +62,14 @@ resource "aquasec_integration_registry" "integration_registry" {
     auth_token    = "test1-test2-test3"
     un_quarantine = false
   }
+
+  auto_scan_time {
+    auto_pull_day   = 1
+    iteration       = 1
+    iteration_type  = "week"
+    time            = "2025-07-09T08:45:00Z"
+    week_days       = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"]
+  }
 }
 ```
 
@@ -100,6 +108,7 @@ resource "aquasec_integration_registry" "integration_registry" {
 - `url` (String) The URL, address or region of the registry
 - `username` (String) The username for registry authentication.
 - `webhook` (Block Set) When enabled, registry events are sent to the given Aqua webhook url (see [below for nested schema](#nestedblock--webhook))
+- `auto_scan_time` (Block Set) When auto_pull is enabled, auto_scan_time has to be configured (see [below for nested schema](#nestedblock--auto_scan_time))
 
 ### Read-Only
 
@@ -123,5 +132,14 @@ Optional:
 - `enabled` (Boolean)
 - `un_quarantine` (Boolean)
 - `url` (String)
+
+<a id="nestedblock--auto_scan_time"></a>
+### Nested schema for `auto_scan_time`
+
+- `auto_pull_day` (Number)
+- `iteration` (Number)
+- `iteration_type` (String)
+- `time` (String)
+- `week_days` (List of string)
 
 

--- a/examples/resources/aquasec_integration_registry/resource.tf
+++ b/examples/resources/aquasec_integration_registry/resource.tf
@@ -47,5 +47,12 @@ resource "aquasec_integration_registry" "integration_registry" {
     auth_token    = "test1-test2-test3"
     un_quarantine = false
   }
+  auto_scan_time {
+    auto_pull_day   = 1
+    iteration       = 1
+    iteration_type  = "week" // "none", "day", "week", "month"
+    time            = "2025-07-09T08:45:00Z" //YYYY-MM-DDTHH:MM:SSZ
+    week_days       = ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday"] // ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]
+  }
 }
 


### PR DESCRIPTION
Fix for error creating integration registry when supersonic feature is enabled

* Modify terraform schema definition for integration registry to include scanner-group-name attribute
* Update the terraform aquasec_integration_registry example

Resolves: SLK-96784