### PR TITLE
fix: TP | Fix aquasec_function_assurance_policy, aquasec_image_assurance_policy and aquasec_kubernetes_assurance_policy (datasource and resource)

### DIFF
--- a/aquasec/data_function_assurance_policy.go
+++ b/aquasec/data_function_assurance_policy.go
@@ -1,13 +1,16 @@
 package aquasec
 
 import (
+	"context"
+
 	"github.com/aquasecurity/terraform-provider-aquasec/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataFunctionAssurancePolicy() *schema.Resource {
 	return &schema.Resource{
-		Read: dataFunctionAssurancePolicyRead,
+		ReadContext: dataFunctionAssurancePolicyRead,
 		Schema: map[string]*schema.Schema{
 			/*
 				"assurance_type": {
@@ -479,6 +482,14 @@ func dataFunctionAssurancePolicy() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"ignore_recently_published_fix_vln": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"ignore_recently_published_fix_vln_period": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"ignore_risk_resources_enabled": {
 				Type:        schema.TypeBool,
 				Description: "Indicates if risk resources are ignored.",
@@ -608,11 +619,47 @@ func dataFunctionAssurancePolicy() *schema.Resource {
 				Description: "Indicates that policy should ignore cases that do not have a known fix.",
 				Computed:    true,
 			},
+			"category": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"aggregated_vulnerability": {
+				Type:        schema.TypeList,
+				Description: "Aggregated vulnerability information.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Description: "Enable the aggregated vulnerability",
+							Computed:    true,
+						},
+						"score_range": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeFloat,
+							},
+							Description: "Indicates score range for vuln score eg [5.5, 6.0]",
+						},
+						"custom_severity_enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates to consider custom severity during control evaluation",
+						},
+						"severity": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Max severity to be allowed in the image",
+						},
+					},
+				},
+			},
 		},
 	}
 }
 
-func dataFunctionAssurancePolicyRead(d *schema.ResourceData, m interface{}) error {
+func dataFunctionAssurancePolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	ac := m.(*client.Client)
 	name := d.Get("name").(string)
 	assurance_type := "function"
@@ -693,9 +740,13 @@ func dataFunctionAssurancePolicyRead(d *schema.ResourceData, m interface{}) erro
 		d.Set("malware_action", iap.MalwareAction)
 		d.Set("partial_results_image_fail", iap.PartialResultsImageFail)
 		d.Set("maximum_score_exclude_no_fix", iap.MaximumScoreExcludeNoFix)
+		d.Set("category", iap.Category)
+		d.Set("ignore_recently_published_fix_vln", iap.IgnoreRecentlyPublishedFixVln)
+		d.Set("ignore_recently_published_fix_vln_period", iap.IgnoreRecentlyPublishedFixVlnPeriod)
+		d.Set("aggregated_vulnerability", flattenAggregatedVulnerability(iap.AggregatedVulnerability))
 		d.SetId(name)
 	} else {
-		return err
+		return diag.FromErr(err)
 	}
 	return nil
 }

--- a/aquasec/data_kubernetes_assurance_policy.go
+++ b/aquasec/data_kubernetes_assurance_policy.go
@@ -1,13 +1,16 @@
 package aquasec
 
 import (
+	"context"
+
 	"github.com/aquasecurity/terraform-provider-aquasec/client"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
 func dataKubernetesAssurancePolicy() *schema.Resource {
 	return &schema.Resource{
-		Read: dataKubernetesAssurancePolicyRead,
+		ReadContext: dataKubernetesAssurancePolicyRead,
 		Schema: map[string]*schema.Schema{
 			/*
 				"assurance_type": {
@@ -64,6 +67,10 @@ func dataKubernetesAssurancePolicy() *schema.Resource {
 			},
 			"control_exclude_no_fix": {
 				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"category": {
+				Type:     schema.TypeString,
 				Computed: true,
 			},
 			"custom_checks_enabled": {
@@ -489,6 +496,14 @@ func dataKubernetesAssurancePolicy() *schema.Resource {
 				Type:     schema.TypeInt,
 				Computed: true,
 			},
+			"ignore_recently_published_fix_vln": {
+				Type:     schema.TypeBool,
+				Computed: true,
+			},
+			"ignore_recently_published_fix_vln_period": {
+				Type:     schema.TypeInt,
+				Computed: true,
+			},
 			"ignore_risk_resources_enabled": {
 				Type:        schema.TypeBool,
 				Description: "Indicates if risk resources are ignored.",
@@ -618,11 +633,43 @@ func dataKubernetesAssurancePolicy() *schema.Resource {
 				Description: "Indicates that policy should ignore cases that do not have a known fix.",
 				Computed:    true,
 			},
+			"aggregated_vulnerability": {
+				Type:        schema.TypeList,
+				Description: "Aggregated vulnerability information.",
+				Computed:    true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates that the control is enabled",
+						},
+						"score_range": {
+							Type:     schema.TypeList,
+							Computed: true,
+							Elem: &schema.Schema{
+								Type: schema.TypeFloat,
+							},
+							Description: "Indicates score range for vuln score eg [5.5, 6.0]",
+						},
+						"custom_severity_enabled": {
+							Type:        schema.TypeBool,
+							Computed:    true,
+							Description: "Indicates to consider custom severity during control evaluation",
+						},
+						"severity": {
+							Type:        schema.TypeString,
+							Computed:    true,
+							Description: "Max severity to be allowed in the image",
+						},
+					},
+				},
+			}, // list
 		},
 	}
 }
 
-func dataKubernetesAssurancePolicyRead(d *schema.ResourceData, m interface{}) error {
+func dataKubernetesAssurancePolicyRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	ac := m.(*client.Client)
 	name := d.Get("name").(string)
 	assurance_type := "kubernetes"
@@ -655,7 +702,7 @@ func dataKubernetesAssurancePolicyRead(d *schema.ResourceData, m interface{}) er
 		d.Set("disallow_malware", iap.DisallowMalware)
 		d.Set("monitored_malware_paths", iap.MonitoredMalwarePaths)
 		d.Set("exceptional_monitored_malware_paths", iap.ExceptionalMonitoredMalwarePaths)
-		d.Set("kubernetes_controls_names", iap.KubenetesControlsNames)
+		d.Set("kubernetes_controls_names", iap.KubernetesControlsNames)
 		d.Set("blacklisted_licenses_enabled", iap.BlacklistedLicensesEnabled)
 		d.Set("blacklisted_licenses", iap.BlacklistedLicenses)
 		d.Set("whitelisted_licenses_enabled", iap.WhitelistedLicensesEnabled)
@@ -687,6 +734,8 @@ func dataKubernetesAssurancePolicyRead(d *schema.ResourceData, m interface{}) er
 		d.Set("enforce_after_days", iap.EnforceAfterDays)
 		d.Set("ignore_recently_published_vln", iap.IgnoreRecentlyPublishedVln)
 		d.Set("ignore_recently_published_vln_period", iap.IgnoreRecentlyPublishedVlnPeriod)
+		d.Set("ignore_recently_published_fix_vln", iap.IgnoreRecentlyPublishedFixVln)
+		d.Set("ignore_recently_published_fix_vln_period", iap.IgnoreRecentlyPublishedFixVlnPeriod)
 		d.Set("ignore_risk_resources_enabled", iap.IgnoreRiskResourcesEnabled)
 		d.Set("ignored_risk_resources", iap.IgnoredRiskResources)
 		d.Set("application_scopes", iap.ApplicationScopes)
@@ -704,9 +753,11 @@ func dataKubernetesAssurancePolicyRead(d *schema.ResourceData, m interface{}) er
 		d.Set("malware_action", iap.MalwareAction)
 		d.Set("partial_results_image_fail", iap.PartialResultsImageFail)
 		d.Set("maximum_score_exclude_no_fix", iap.MaximumScoreExcludeNoFix)
+		d.Set("category", iap.Category)
+		d.Set("aggregated_vulnerability", flattenAggregatedVulnerability(iap.AggregatedVulnerability))
 		d.SetId(name)
 	} else {
-		return err
+		return diag.FromErr(err)
 	}
 	return nil
 }

--- a/aquasec/resource_image_assurance_policy_test.go
+++ b/aquasec/resource_image_assurance_policy_test.go
@@ -14,13 +14,14 @@ func TestAquasecImageAssurancePolicy(t *testing.T) {
 	description := "Created using Terraform"
 	name := acctest.RandomWithPrefix("terraform-test")
 	application_scopes := "Global"
+	ignore_recently_published_fix_vln_period := 30
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
 		Providers:    testAccProviders,
 		CheckDestroy: CheckDestroy("aquasec_image_assurance_policy.terraformiap"),
 		Steps: []resource.TestStep{
 			{
-				Config: testAccCheckImageAssurancePolicy(description, name, application_scopes),
+				Config: testAccCheckImageAssurancePolicy(description, name, application_scopes, ignore_recently_published_fix_vln_period),
 				Check: resource.ComposeTestCheckFunc(
 					testAccCheckImageAssurancePolicyExists("aquasec_image_assurance_policy.terraformiap"),
 				),
@@ -34,7 +35,7 @@ func TestAquasecImageAssurancePolicy(t *testing.T) {
 	})
 }
 
-func testAccCheckImageAssurancePolicy(description string, name string, application_scopes string) string {
+func testAccCheckImageAssurancePolicy(description string, name string, application_scopes string, ignore_recently_published_fix_vln_period int) string {
 	return fmt.Sprintf(`
 	resource "aquasec_image_assurance_policy" "terraformiap" {
 		description = "%s"
@@ -42,7 +43,8 @@ func testAccCheckImageAssurancePolicy(description string, name string, applicati
 		application_scopes = [
 			"%s"
 		]
-	}`, description, name, application_scopes)
+		ignore_recently_published_fix_vln_period = %d
+	}`, description, name, application_scopes, ignore_recently_published_fix_vln_period)
 
 }
 

--- a/client/assurance_policy.go
+++ b/client/assurance_policy.go
@@ -4,90 +4,93 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/pkg/errors"
 	"io"
 	"log"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 type AssurancePolicy struct {
-	AssuranceType                    string              `json:"assurance_type"`
-	Id                               int                 `json:"id"`
-	Name                             string              `json:"name"`
-	Author                           string              `json:"author"`
-	Registry                         string              `json:"registry,omitempty"`
-	Lastupdate                       string              `json:"lastupdate,omitempty"`
-	CvssSeverityEnabled              bool                `json:"cvss_severity_enabled"`
-	CvssSeverity                     string              `json:"cvss_severity"`
-	CvssSeverityExcludeNoFix         bool                `json:"cvss_severity_exclude_no_fix"`
-	CustomSeverityEnabled            bool                `json:"custom_severity_enabled"`
-	MaximumScoreEnabled              bool                `json:"maximum_score_enabled"`
-	MaximumScore                     float64             `json:"maximum_score"`
-	ControlExcludeNoFix              bool                `json:"control_exclude_no_fix"`
-	CustomChecksEnabled              bool                `json:"custom_checks_enabled"`
-	ScapEnabled                      bool                `json:"scap_enabled"`
-	CvesBlackListEnabled             bool                `json:"cves_black_list_enabled"`
-	PackagesBlackListEnabled         bool                `json:"packages_black_list_enabled"`
-	PackagesWhiteListEnabled         bool                `json:"packages_white_list_enabled"`
-	OnlyNoneRootUsers                bool                `json:"only_none_root_users"`
-	TrustedBaseImagesEnabled         bool                `json:"trusted_base_images_enabled"`
-	ScanSensitiveData                bool                `json:"scan_sensitive_data"`
-	AuditOnFailure                   bool                `json:"audit_on_failure"`
-	FailCicd                         bool                `json:"fail_cicd,omitempty"`
-	BlockFailed                      bool                `json:"block_failed"`
-	DisallowMalware                  bool                `json:"disallow_malware"`
-	MonitoredMalwarePaths            []interface{}       `json:"monitored_malware_paths"`
-	ExceptionalMonitoredMalwarePaths []interface{}       `json:"exceptional_monitored_malware_paths"`
-	BlacklistedLicensesEnabled       bool                `json:"blacklisted_licenses_enabled"`
-	BlacklistedLicenses              []string            `json:"blacklisted_licenses"`
-	WhitelistedLicensesEnabled       bool                `json:"whitelisted_licenses_enabled"`
-	WhitelistedLicenses              []string            `json:"whitelisted_licenses"`
-	CustomChecks                     []Checks            `json:"custom_checks"`
-	ScapFiles                        []interface{}       `json:"scap_files"`
-	Scope                            Scopes              `json:"scope"`
-	Registries                       interface{}         `json:"registries"`
-	Labels                           interface{}         `json:"labels"`
-	Images                           interface{}         `json:"images"`
-	CvesBlackList                    []string            `json:"cves_black_list"`
-	PackagesBlackList                []ListPackages      `json:"packages_black_list"`
-	PackagesWhiteList                []ListPackages      `json:"packages_white_list"`
-	AllowedImages                    interface{}         `json:"allowed_images"`
-	TrustedBaseImages                []BaseImagesTrusted `json:"trusted_base_images"`
-	ReadOnly                         bool                `json:"read_only"`
-	ForceMicroenforcer               bool                `json:"force_microenforcer"`
-	DockerCisEnabled                 bool                `json:"docker_cis_enabled"`
-	KubeCisEnabled                   bool                `json:"kube_cis_enabled"`
-	EnforceExcessivePermissions      bool                `json:"enforce_excessive_permissions"`
-	FunctionIntegrityEnabled         bool                `json:"function_integrity_enabled"`
-	DtaEnabled                       bool                `json:"dta_enabled"`
-	CvesWhiteList                    []string            `json:"cves_white_list"`
-	CvesWhiteListEnabled             bool                `json:"cves_white_list_enabled"`
-	BlacklistPermissionsEnabled      bool                `json:"blacklist_permissions_enabled"`
-	BlacklistPermissions             []interface{}       `json:"blacklist_permissions"`
-	Enabled                          bool                `json:"enabled,omitempty"`
-	Enforce                          bool                `json:"enforce,omitempty"`
-	EnforceAfterDays                 int                 `json:"enforce_after_days,omitempty"`
-	IgnoreRecentlyPublishedVln       bool                `json:"ignore_recently_published_vln"`
-	IgnoreRecentlyPublishedVlnPeriod int                 `json:"ignore_recently_published_vln_period"`
-	IgnoreRiskResourcesEnabled       bool                `json:"ignore_risk_resources_enabled"`
-	IgnoredRiskResources             []string            `json:"ignored_risk_resources"`
-	ApplicationScopes                []string            `json:"application_scopes"`
-	AutoScanEnabled                  bool                `json:"auto_scan_enabled"`
-	AutoScanConfigured               bool                `json:"auto_scan_configured"`
-	AutoScanTime                     ScanTimeAuto        `json:"auto_scan_time"`
-	RequiredLabelsEnabled            bool                `json:"required_labels_enabled"`
-	RequiredLabels                   []Labels            `json:"required_labels"`
-	ForbiddenLabelsEnabled           bool                `json:"forbidden_labels_enabled"`
-	ForbiddenLabels                  []Labels            `json:"forbidden_labels"`
-	DomainName                       string              `json:"domain_name,omitempty"`
-	Domain                           string              `json:"domain,omitempty"`
-	Description                      string              `json:"description"`
-	DtaSeverity                      string              `json:"dta_severity"`
-	ScanNfsMounts                    bool                `json:"scan_nfs_mounts"`
-	MalwareAction                    string              `json:"malware_action"`
-	PartialResultsImageFail          bool                `json:"partial_results_image_fail"`
-	MaximumScoreExcludeNoFix         bool                `json:"maximum_score_exclude_no_fix"`
-	KubenetesControlsNames           []string            `json:"kubernetes_controls_names"`
+	AssuranceType                       string              `json:"assurance_type"`
+	Id                                  int                 `json:"id"`
+	Name                                string              `json:"name"`
+	Author                              string              `json:"author"`
+	Registry                            string              `json:"registry,omitempty"`
+	Lastupdate                          string              `json:"lastupdate,omitempty"`
+	CvssSeverityEnabled                 bool                `json:"cvss_severity_enabled"`
+	CvssSeverity                        string              `json:"cvss_severity"`
+	CvssSeverityExcludeNoFix            bool                `json:"cvss_severity_exclude_no_fix"`
+	CustomSeverityEnabled               bool                `json:"custom_severity_enabled"`
+	MaximumScoreEnabled                 bool                `json:"maximum_score_enabled"`
+	MaximumScore                        float64             `json:"maximum_score"`
+	ControlExcludeNoFix                 bool                `json:"control_exclude_no_fix"`
+	Category                            string              `json:"category"`
+	CustomChecksEnabled                 bool                `json:"custom_checks_enabled"`
+	ScapEnabled                         bool                `json:"scap_enabled"`
+	CvesBlackListEnabled                bool                `json:"cves_black_list_enabled"`
+	PackagesBlackListEnabled            bool                `json:"packages_black_list_enabled"`
+	PackagesWhiteListEnabled            bool                `json:"packages_white_list_enabled"`
+	OnlyNoneRootUsers                   bool                `json:"only_none_root_users"`
+	TrustedBaseImagesEnabled            bool                `json:"trusted_base_images_enabled"`
+	ScanSensitiveData                   bool                `json:"scan_sensitive_data"`
+	AuditOnFailure                      bool                `json:"audit_on_failure"`
+	FailCicd                            bool                `json:"fail_cicd,omitempty"`
+	BlockFailed                         bool                `json:"block_failed"`
+	DisallowMalware                     bool                `json:"disallow_malware"`
+	MonitoredMalwarePaths               []interface{}       `json:"monitored_malware_paths"`
+	ExceptionalMonitoredMalwarePaths    []interface{}       `json:"exceptional_monitored_malware_paths"`
+	BlacklistedLicensesEnabled          bool                `json:"blacklisted_licenses_enabled"`
+	BlacklistedLicenses                 []string            `json:"blacklisted_licenses"`
+	WhitelistedLicensesEnabled          bool                `json:"whitelisted_licenses_enabled"`
+	WhitelistedLicenses                 []string            `json:"whitelisted_licenses"`
+	CustomChecks                        []Checks            `json:"custom_checks"`
+	ScapFiles                           []interface{}       `json:"scap_files"`
+	Scope                               Scopes              `json:"scope"`
+	Registries                          interface{}         `json:"registries"`
+	Labels                              interface{}         `json:"labels"`
+	Images                              interface{}         `json:"images"`
+	CvesBlackList                       []string            `json:"cves_black_list"`
+	PackagesBlackList                   []ListPackages      `json:"packages_black_list"`
+	PackagesWhiteList                   []ListPackages      `json:"packages_white_list"`
+	AllowedImages                       interface{}         `json:"allowed_images"`
+	TrustedBaseImages                   []BaseImagesTrusted `json:"trusted_base_images"`
+	ReadOnly                            bool                `json:"read_only"`
+	ForceMicroenforcer                  bool                `json:"force_microenforcer"`
+	DockerCisEnabled                    bool                `json:"docker_cis_enabled"`
+	KubeCisEnabled                      bool                `json:"kube_cis_enabled"`
+	EnforceExcessivePermissions         bool                `json:"enforce_excessive_permissions"`
+	FunctionIntegrityEnabled            bool                `json:"function_integrity_enabled"`
+	DtaEnabled                          bool                `json:"dta_enabled"`
+	CvesWhiteList                       []string            `json:"cves_white_list"`
+	CvesWhiteListEnabled                bool                `json:"cves_white_list_enabled"`
+	BlacklistPermissionsEnabled         bool                `json:"blacklist_permissions_enabled"`
+	BlacklistPermissions                []interface{}       `json:"blacklist_permissions"`
+	Enabled                             bool                `json:"enabled,omitempty"`
+	Enforce                             bool                `json:"enforce,omitempty"`
+	EnforceAfterDays                    int                 `json:"enforce_after_days,omitempty"`
+	IgnoreRecentlyPublishedVln          bool                `json:"ignore_recently_published_vln"`
+	IgnoreRecentlyPublishedVlnPeriod    int                 `json:"ignore_recently_published_vln_period"`
+	IgnoreRecentlyPublishedFixVln       bool                `json:"ignore_recently_published_fix_vln"`
+	IgnoreRecentlyPublishedFixVlnPeriod int                 `json:"ignore_recently_published_fix_vln_period"`
+	IgnoreRiskResourcesEnabled          bool                `json:"ignore_risk_resources_enabled"`
+	IgnoredRiskResources                []string            `json:"ignored_risk_resources"`
+	ApplicationScopes                   []string            `json:"application_scopes"`
+	AutoScanEnabled                     bool                `json:"auto_scan_enabled"`
+	AutoScanConfigured                  bool                `json:"auto_scan_configured"`
+	AutoScanTime                        ScanTimeAuto        `json:"auto_scan_time"`
+	RequiredLabelsEnabled               bool                `json:"required_labels_enabled"`
+	RequiredLabels                      []Labels            `json:"required_labels"`
+	ForbiddenLabelsEnabled              bool                `json:"forbidden_labels_enabled"`
+	ForbiddenLabels                     []Labels            `json:"forbidden_labels"`
+	DomainName                          string              `json:"domain_name,omitempty"`
+	Domain                              string              `json:"domain,omitempty"`
+	Description                         string              `json:"description"`
+	DtaSeverity                         string              `json:"dta_severity"`
+	ScanNfsMounts                       bool                `json:"scan_nfs_mounts"`
+	MalwareAction                       string              `json:"malware_action"`
+	PartialResultsImageFail             bool                `json:"partial_results_image_fail"`
+	MaximumScoreExcludeNoFix            bool                `json:"maximum_score_exclude_no_fix"`
 	//JSON
 	CustomSeverity              string                  `json:"custom_severity"`
 	VulnerabilityExploitability bool                    `json:"vulnerability_exploitability"`
@@ -107,6 +110,7 @@ type AssurancePolicy struct {
 	OpenshiftHardeningEnabled   bool                    `json:"openshift_hardening_enabled"`
 	KubernetesControlsAvdIds    []string                `json:"kubernetes_controls_avd_ids"`
 	VulnerabilityScoreRange     []int                   `json:"vulnerability_score_range"`
+	AggregatedVulnerability     AggregatedVulnerability `json:"aggregated_vulnerability"`
 }
 
 type Checks struct {
@@ -151,8 +155,12 @@ type ListPackages struct {
 }
 
 type BaseImagesTrusted struct {
-	Registry  string `json:"registry"`
-	Imagename string `json:"imagename"`
+	Registry    string `json:"registry"`
+	Imagename   string `json:"imagename"`
+	Author      string `json:"author"`
+	ImageDigest string `json:"imagedigest"`
+	ImageID     int    `json:"imageid"`
+	LastUpdated int    `json:"lastupdated"`
 }
 
 type ScanTimeAuto struct {
@@ -180,6 +188,22 @@ type KubernetesControls struct {
 	Kind        string `json:"kind"`
 	OOTB        bool   `json:"ootb"`
 	AvdID       string `json:"avd_id"`
+}
+
+type AggregatedVulnerability struct {
+	Enabled               bool      `json:"enabled"`
+	ScoreRange            []float32 `json:"score_range"`
+	CustomSeverityEnabled bool      `json:"custom_severity_enabled"`
+	Severity              string    `json:"severity"`
+}
+
+type TrustedBaseImages struct {
+	Author      string `json:"author"`
+	ImageDigest string `json:"image_digest"`
+	ImageID     int    `json:"image_id"`
+	ImageName   string `json:"image_name"`
+	LastUpdated int    `json:"last_updated"`
+	Registry    string `json:"registry"`
 }
 
 type KubernetesControlsArray []KubernetesControls

--- a/docs/data-sources/function_assurance_policy.md
+++ b/docs/data-sources/function_assurance_policy.md
@@ -21,6 +21,7 @@ description: |-
 
 ### Read-Only
 
+- `aggregated_vulnerability` (List of Object) Aggregated vulnerability information. (see [below for nested schema](#nestedatt--aggregated_vulnerability))
 - `allowed_images` (List of String) List of explicitly allowed images.
 - `application_scopes` (List of String)
 - `audit_on_failure` (Boolean) Indicates if auditing for failures.
@@ -33,6 +34,7 @@ description: |-
 - `blacklisted_licenses` (List of String) List of blacklisted licenses.
 - `blacklisted_licenses_enabled` (Boolean) Indicates if license blacklist is relevant.
 - `block_failed` (Boolean) Indicates if failed images are blocked.
+- `category` (String)
 - `control_exclude_no_fix` (Boolean)
 - `custom_checks` (List of Object) List of Custom user scripts for checks. (see [below for nested schema](#nestedatt--custom_checks))
 - `custom_checks_enabled` (Boolean) Indicates if scanning should include custom checks.
@@ -62,6 +64,8 @@ description: |-
 - `force_microenforcer` (Boolean)
 - `function_integrity_enabled` (Boolean)
 - `id` (String) The ID of this resource.
+- `ignore_recently_published_fix_vln` (Boolean)
+- `ignore_recently_published_fix_vln_period` (Number)
 - `ignore_recently_published_vln` (Boolean)
 - `ignore_recently_published_vln_period` (Number)
 - `ignore_risk_resources_enabled` (Boolean) Indicates if risk resources are ignored.
@@ -94,6 +98,17 @@ description: |-
 - `trusted_base_images_enabled` (Boolean) Indicates if list of trusted base images is relevant.
 - `whitelisted_licenses` (List of String) List of whitelisted licenses.
 - `whitelisted_licenses_enabled` (Boolean) Indicates if license blacklist is relevant.
+
+<a id="nestedatt--aggregated_vulnerability"></a>
+### Nested Schema for `aggregated_vulnerability`
+
+Read-Only:
+
+- `custom_severity_enabled` (Boolean)
+- `enabled` (Boolean)
+- `score_range` (List of Number)
+- `severity` (String)
+
 
 <a id="nestedatt--auto_scan_time"></a>
 ### Nested Schema for `auto_scan_time`

--- a/docs/data-sources/image_assurance_policy.md
+++ b/docs/data-sources/image_assurance_policy.md
@@ -21,6 +21,7 @@ description: |-
 
 ### Read-Only
 
+- `aggregated_vulnerability` (List of Object) Aggregated vulnerability information. (see [below for nested schema](#nestedatt--aggregated_vulnerability))
 - `allowed_images` (List of String) List of explicitly allowed images.
 - `application_scopes` (List of String)
 - `audit_on_failure` (Boolean) Indicates if auditing for failures.
@@ -33,6 +34,7 @@ description: |-
 - `blacklisted_licenses` (List of String) List of blacklisted licenses.
 - `blacklisted_licenses_enabled` (Boolean) Indicates if license blacklist is relevant.
 - `block_failed` (Boolean) Indicates if failed images are blocked.
+- `category` (String)
 - `control_exclude_no_fix` (Boolean)
 - `custom_checks` (List of Object) List of Custom user scripts for checks. (see [below for nested schema](#nestedatt--custom_checks))
 - `custom_checks_enabled` (Boolean) Indicates if scanning should include custom checks.
@@ -62,6 +64,8 @@ description: |-
 - `force_microenforcer` (Boolean)
 - `function_integrity_enabled` (Boolean)
 - `id` (String) The ID of this resource.
+- `ignore_recently_published_fix_vln` (Boolean)
+- `ignore_recently_published_fix_vln_period` (Number)
 - `ignore_recently_published_vln` (Boolean)
 - `ignore_recently_published_vln_period` (Number)
 - `ignore_risk_resources_enabled` (Boolean) Indicates if risk resources are ignored.
@@ -94,6 +98,17 @@ description: |-
 - `trusted_base_images_enabled` (Boolean) Indicates if list of trusted base images is relevant.
 - `whitelisted_licenses` (List of String) List of whitelisted licenses.
 - `whitelisted_licenses_enabled` (Boolean) Indicates if license blacklist is relevant.
+
+<a id="nestedatt--aggregated_vulnerability"></a>
+### Nested Schema for `aggregated_vulnerability`
+
+Read-Only:
+
+- `custom_severity_enabled` (Boolean)
+- `enabled` (Boolean)
+- `score_range` (List of Number)
+- `severity` (String)
+
 
 <a id="nestedatt--auto_scan_time"></a>
 ### Nested Schema for `auto_scan_time`

--- a/docs/data-sources/kubernetes_assurance_policy.md
+++ b/docs/data-sources/kubernetes_assurance_policy.md
@@ -21,6 +21,7 @@ description: |-
 
 ### Read-Only
 
+- `aggregated_vulnerability` (List of Object) Aggregated vulnerability information. (see [below for nested schema](#nestedatt--aggregated_vulnerability))
 - `allowed_images` (List of String) List of explicitly allowed images.
 - `application_scopes` (List of String)
 - `audit_on_failure` (Boolean) Indicates if auditing for failures.
@@ -33,6 +34,7 @@ description: |-
 - `blacklisted_licenses` (List of String) List of blacklisted licenses.
 - `blacklisted_licenses_enabled` (Boolean) Indicates if license blacklist is relevant.
 - `block_failed` (Boolean) Indicates if failed images are blocked.
+- `category` (String)
 - `control_exclude_no_fix` (Boolean)
 - `custom_checks` (List of Object) List of Custom user scripts for checks. (see [below for nested schema](#nestedatt--custom_checks))
 - `custom_checks_enabled` (Boolean) Indicates if scanning should include custom checks.
@@ -62,6 +64,8 @@ description: |-
 - `force_microenforcer` (Boolean)
 - `function_integrity_enabled` (Boolean)
 - `id` (String) The ID of this resource.
+- `ignore_recently_published_fix_vln` (Boolean)
+- `ignore_recently_published_fix_vln_period` (Number)
 - `ignore_recently_published_vln` (Boolean)
 - `ignore_recently_published_vln_period` (Number)
 - `ignore_risk_resources_enabled` (Boolean) Indicates if risk resources are ignored.
@@ -95,6 +99,17 @@ description: |-
 - `trusted_base_images_enabled` (Boolean) Indicates if list of trusted base images is relevant.
 - `whitelisted_licenses` (List of String) List of whitelisted licenses.
 - `whitelisted_licenses_enabled` (Boolean) Indicates if license blacklist is relevant.
+
+<a id="nestedatt--aggregated_vulnerability"></a>
+### Nested Schema for `aggregated_vulnerability`
+
+Read-Only:
+
+- `custom_severity_enabled` (Boolean)
+- `enabled` (Boolean)
+- `score_range` (List of Number)
+- `severity` (String)
+
 
 <a id="nestedatt--auto_scan_time"></a>
 ### Nested Schema for `auto_scan_time`

--- a/docs/resources/aqua_api_key.md
+++ b/docs/resources/aqua_api_key.md
@@ -34,8 +34,6 @@ resource "aquasec_aqua_api_key" "terraform_api_key" {
     ]
     //Whether the apikey is enabled or not.
     enabled = true
-    whitelisted = false
-    iac_token = false
 }
 ```
 

--- a/docs/resources/function_assurance_policy.md
+++ b/docs/resources/function_assurance_policy.md
@@ -52,7 +52,7 @@ resource "aquasec_function_assurance_policy" "example_function_assurance_policy"
 
 ### Optional
 
-- `aggregated_vulnerability` (Map of String) Aggregated vulnerability information.
+- `aggregated_vulnerability` (Block List) Aggregated vulnerability information. (see [below for nested schema](#nestedblock--aggregated_vulnerability))
 - `allowed_images` (List of String) List of explicitly allowed images.
 - `assurance_type` (String) What type of assurance policy is described.
 - `audit_on_failure` (Boolean) Indicates if auditing for failures.
@@ -65,6 +65,7 @@ resource "aquasec_function_assurance_policy" "example_function_assurance_policy"
 - `blacklisted_licenses` (List of String) List of blacklisted licenses.
 - `blacklisted_licenses_enabled` (Boolean) Indicates if license blacklist is relevant.
 - `block_failed` (Boolean) Indicates if failed images are blocked.
+- `category` (String)
 - `control_exclude_no_fix` (Boolean)
 - `custom_checks` (Block List) List of Custom user scripts for checks. (see [below for nested schema](#nestedblock--custom_checks))
 - `custom_checks_enabled` (Boolean) Indicates if scanning should include custom checks.
@@ -97,6 +98,8 @@ resource "aquasec_function_assurance_policy" "example_function_assurance_policy"
 - `force_microenforcer` (Boolean)
 - `function_integrity_enabled` (Boolean)
 - `ignore_base_image_vln` (Boolean)
+- `ignore_recently_published_fix_vln` (Boolean)
+- `ignore_recently_published_fix_vln_period` (Number)
 - `ignore_recently_published_vln` (Boolean)
 - `ignore_recently_published_vln_period` (Number)
 - `ignore_risk_resources_enabled` (Boolean) Indicates if risk resources are ignored.
@@ -147,6 +150,17 @@ resource "aquasec_function_assurance_policy" "example_function_assurance_policy"
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--aggregated_vulnerability"></a>
+### Nested Schema for `aggregated_vulnerability`
+
+Optional:
+
+- `custom_severity_enabled` (Boolean) Indicates to consider custom severity during control evaluation
+- `enabled` (Boolean) Enable the aggregated vulnerability
+- `score_range` (List of Number) Indicates score range for vuln score eg [5.5, 6.0]
+- `severity` (String) Max severity to be allowed in the image
+
 
 <a id="nestedblock--auto_scan_time"></a>
 ### Nested Schema for `auto_scan_time`

--- a/docs/resources/image_assurance_policy.md
+++ b/docs/resources/image_assurance_policy.md
@@ -43,7 +43,7 @@ resource "aquasec_image_assurance_policy" "test_image_policy" {
 
 ### Optional
 
-- `aggregated_vulnerability` (Map of String) Aggregated vulnerability information.
+- `aggregated_vulnerability` (Block List) Aggregated vulnerability information. (see [below for nested schema](#nestedblock--aggregated_vulnerability))
 - `allowed_images` (List of String) List of explicitly allowed images.
 - `assurance_type` (String) What type of assurance policy is described.
 - `audit_on_failure` (Boolean) Indicates if auditing for failures.
@@ -56,6 +56,7 @@ resource "aquasec_image_assurance_policy" "test_image_policy" {
 - `blacklisted_licenses` (List of String) List of blacklisted licenses.
 - `blacklisted_licenses_enabled` (Boolean) Indicates if license blacklist is relevant.
 - `block_failed` (Boolean) Indicates if failed images are blocked.
+- `category` (String)
 - `control_exclude_no_fix` (Boolean)
 - `custom_checks` (Block List) List of Custom user scripts for checks. (see [below for nested schema](#nestedblock--custom_checks))
 - `custom_checks_enabled` (Boolean) Indicates if scanning should include custom checks.
@@ -88,6 +89,8 @@ resource "aquasec_image_assurance_policy" "test_image_policy" {
 - `force_microenforcer` (Boolean)
 - `function_integrity_enabled` (Boolean)
 - `ignore_base_image_vln` (Boolean)
+- `ignore_recently_published_fix_vln` (Boolean)
+- `ignore_recently_published_fix_vln_period` (Number)
 - `ignore_recently_published_vln` (Boolean)
 - `ignore_recently_published_vln_period` (Number)
 - `ignore_risk_resources_enabled` (Boolean) Indicates if risk resources are ignored.
@@ -138,6 +141,17 @@ resource "aquasec_image_assurance_policy" "test_image_policy" {
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--aggregated_vulnerability"></a>
+### Nested Schema for `aggregated_vulnerability`
+
+Optional:
+
+- `custom_severity_enabled` (Boolean) Indicates to consider custom severity during control evaluation
+- `enabled` (Boolean) Enable the aggregated vulnerability
+- `score_range` (List of Number) Indicates score range for vuln score eg [5.5, 6.0]
+- `severity` (String) Max severity to be allowed in the image
+
 
 <a id="nestedblock--auto_scan_time"></a>
 ### Nested Schema for `auto_scan_time`

--- a/docs/resources/kubernetes_assurance_policy.md
+++ b/docs/resources/kubernetes_assurance_policy.md
@@ -46,7 +46,7 @@ resource "aquasec_kubernetes_assurance_policy" "example_kubernetes_assurance_pol
 
 ### Optional
 
-- `aggregated_vulnerability` (Map of String) Aggregated vulnerability information.
+- `aggregated_vulnerability` (Block List) Aggregated vulnerability information. (see [below for nested schema](#nestedblock--aggregated_vulnerability))
 - `allowed_images` (List of String) List of explicitly allowed images.
 - `assurance_type` (String) What type of assurance policy is described.
 - `audit_on_failure` (Boolean) Indicates if auditing for failures.
@@ -59,6 +59,7 @@ resource "aquasec_kubernetes_assurance_policy" "example_kubernetes_assurance_pol
 - `blacklisted_licenses` (List of String) List of blacklisted licenses.
 - `blacklisted_licenses_enabled` (Boolean) Indicates if license blacklist is relevant.
 - `block_failed` (Boolean) Indicates if failed images are blocked.
+- `category` (String)
 - `control_exclude_no_fix` (Boolean)
 - `custom_checks` (Block List) List of Custom user scripts for checks. (see [below for nested schema](#nestedblock--custom_checks))
 - `custom_checks_enabled` (Boolean) Indicates if scanning should include custom checks.
@@ -91,6 +92,8 @@ resource "aquasec_kubernetes_assurance_policy" "example_kubernetes_assurance_pol
 - `force_microenforcer` (Boolean)
 - `function_integrity_enabled` (Boolean)
 - `ignore_base_image_vln` (Boolean)
+- `ignore_recently_published_fix_vln` (Boolean)
+- `ignore_recently_published_fix_vln_period` (Number)
 - `ignore_recently_published_vln` (Boolean)
 - `ignore_recently_published_vln_period` (Number)
 - `ignore_risk_resources_enabled` (Boolean) Indicates if risk resources are ignored.
@@ -141,6 +144,17 @@ resource "aquasec_kubernetes_assurance_policy" "example_kubernetes_assurance_pol
 ### Read-Only
 
 - `id` (String) The ID of this resource.
+
+<a id="nestedblock--aggregated_vulnerability"></a>
+### Nested Schema for `aggregated_vulnerability`
+
+Optional:
+
+- `custom_severity_enabled` (Boolean) Indicates to consider custom severity during control evaluation
+- `enabled` (Boolean) Indicates that the control is enabled
+- `score_range` (List of Number) Indicates score range for vuln score eg [5.5, 6.0]
+- `severity` (String) Max severity to be allowed in the image
+
 
 <a id="nestedblock--auto_scan_time"></a>
 ### Nested Schema for `auto_scan_time`


### PR DESCRIPTION
Implementation:

* Updated the schema with adding the missing attribute which API was receiving but was not mentioned in the schema.
* Updated the Terraform acceptance test to increase the coverage for assurance policy.
* Updated the document and example with adding all the newly added attribute.
* Updated the function definition by adding context attribute in both data_source and resource.

Impacted Resources:
* aquasec_image_assurance_policy
* aquasec_function_assurance_policy
* aquasec_kubernetes_assurance_policy

Resolves: SAAS-28326, SAAS-28327, SAAS-28328