### PR TITLE
Fix runtime-policies port detection control drift (bug) and malware forensic collection (missing)

### DIFF
--- a/aquasec/resource_container_runtime_policy.go
+++ b/aquasec/resource_container_runtime_policy.go
@@ -1981,11 +1981,12 @@ func expandContainerRuntimePolicy(d *schema.ResourceData) *client.RuntimePolicy 
 		v := malwareScanOptionsMap.([]interface{})[0].(map[string]interface{})
 
 		crp.MalwareScanOptions = client.MalwareScanOptions{
-			Enabled:            v["enabled"].(bool),
-			Action:             v["action"].(string),
-			ExcludeDirectories: convertStringArrNull(v["exclude_directories"].([]interface{})),
-			ExcludeProcesses:   convertStringArrNull(v["exclude_processes"].([]interface{})),
-			IncludeDirectories: convertStringArrNull(v["include_directories"].([]interface{})),
+			Enabled:               v["enabled"].(bool),
+			Action:                v["action"].(string),
+			ExcludeDirectories:    convertStringArrNull(v["exclude_directories"].([]interface{})),
+			ExcludeProcesses:      convertStringArrNull(v["exclude_processes"].([]interface{})),
+			IncludeDirectories:    convertStringArrNull(v["include_directories"].([]interface{})),
+			FileForensicCollection: v["file_forensic_collection"].(bool),
 		}
 	}
 

--- a/aquasec/resource_container_runtime_policy.go
+++ b/aquasec/resource_container_runtime_policy.go
@@ -435,7 +435,6 @@ func resourceContainerRuntimePolicy() *schema.Resource {
 				Type:        schema.TypeBool,
 				Description: "",
 				Optional:    true,
-				Default:     true,
 			}, //bool
 			"enable_crypto_mining_dns": {
 				Type:        schema.TypeBool,

--- a/aquasec/resource_container_runtime_policy_test.go
+++ b/aquasec/resource_container_runtime_policy_test.go
@@ -305,6 +305,11 @@ func TestResourceAquasecFullContainerRuntimePolicyCreate(t *testing.T) {
 					resource.TestCheckResourceAttr(rootRef, "allowed_registries.0.allowed_registries.#", "1"),
 					resource.TestCheckResourceAttr(rootRef, "allowed_registries.0.allowed_registries.0", "Docker Hub"),
 					resource.TestCheckResourceAttr(rootRef, "allowed_registries.0.enabled", "true"),
+					
+					// Malware scan options
+					resource.TestCheckResourceAttr(rootRef, "malware_scan_options.0.enabled", "true"),
+					resource.TestCheckResourceAttr(rootRef, "malware_scan_options.0.action", "alert"),
+					resource.TestCheckResourceAttr(rootRef, "malware_scan_options.0.file_forensic_collection", "false"),
 
 					//todo: bring back after we upgrade the testing env
 					//resource.TestCheckResourceAttr(rootRef, "monitor_system_time_changes", "true"),

--- a/aquasec/resource_host_runtime_policy.go
+++ b/aquasec/resource_host_runtime_policy.go
@@ -518,7 +518,6 @@ func resourceHostRuntimePolicy() *schema.Resource {
 			"enable_ip_reputation": {
 				Type:        schema.TypeBool,
 				Description: "",
-				Default:     true,
 				Optional:    true,
 			}, //bool
 			"fork_guard_process_limit": {

--- a/aquasec/resource_host_runtime_policy.go
+++ b/aquasec/resource_host_runtime_policy.go
@@ -474,6 +474,11 @@ func resourceHostRuntimePolicy() *schema.Resource {
 							},
 							Optional: true,
 						},
+						"file_forensic_collection": {
+							Type:        schema.TypeBool,
+							Description: "Whether to enable file forensic collection.",
+							Optional:    true,
+						},
 					},
 				},
 				Optional: true,

--- a/aquasec/resource_host_runtime_policy.go
+++ b/aquasec/resource_host_runtime_policy.go
@@ -2117,11 +2117,12 @@ func expandHostRuntimePolicy(d *schema.ResourceData) *client.RuntimePolicy {
 		v := malwareScanOptionsMap.([]interface{})[0].(map[string]interface{})
 
 		crp.MalwareScanOptions = client.MalwareScanOptions{
-			Enabled:            v["enabled"].(bool),
-			Action:             v["action"].(string),
-			ExcludeDirectories: convertStringArrNull(v["exclude_directories"].([]interface{})),
-			ExcludeProcesses:   convertStringArrNull(v["exclude_processes"].([]interface{})),
-			IncludeDirectories: convertStringArrNull(v["include_directories"].([]interface{})),
+			Enabled:               v["enabled"].(bool),
+			Action:                v["action"].(string),
+			ExcludeDirectories:    convertStringArrNull(v["exclude_directories"].([]interface{})),
+			ExcludeProcesses:      convertStringArrNull(v["exclude_processes"].([]interface{})),
+			IncludeDirectories:    convertStringArrNull(v["include_directories"].([]interface{})),
+			FileForensicCollection: v["file_forensic_collection"].(bool),
 		}
 	}
 
@@ -2682,11 +2683,12 @@ func flattenMalwareScanOptions(monitoring client.MalwareScanOptions) []map[strin
 	//}
 	return []map[string]interface{}{
 		{
-			"enabled":             monitoring.Enabled,
-			"action":              monitoring.Action,
-			"exclude_directories": monitoring.ExcludeDirectories,
-			"exclude_processes":   monitoring.ExcludeProcesses,
-			"include_directories": monitoring.IncludeDirectories,
+			"enabled":                monitoring.Enabled,
+			"action":                 monitoring.Action,
+			"exclude_directories":    monitoring.ExcludeDirectories,
+			"exclude_processes":      monitoring.ExcludeProcesses,
+			"include_directories":    monitoring.IncludeDirectories,
+			"file_forensic_collection": monitoring.FileForensicCollection,
 		},
 	}
 }

--- a/aquasec/resource_host_runtime_policy_test.go
+++ b/aquasec/resource_host_runtime_policy_test.go
@@ -103,6 +103,11 @@ func TestResourceAquasecComplexHostRuntimePolicyCreate(t *testing.T) {
 					//resource.TestCheckResourceAttr(rootRef, "monitor_system_time_changes", "true"),
 					//resource.TestCheckResourceAttr(rootRef, "monitor_windows_services", "true"),
 					resource.TestCheckResourceAttr(rootRef, "monitor_system_log_integrity", "true"),
+					
+					// Malware scan options
+					resource.TestCheckResourceAttr(rootRef, "malware_scan_options.0.enabled", "true"),
+					resource.TestCheckResourceAttr(rootRef, "malware_scan_options.0.action", "alert"),
+					resource.TestCheckResourceAttr(rootRef, "malware_scan_options.0.file_forensic_collection", "true"),
 				),
 			},
 		},
@@ -154,6 +159,15 @@ func getComplexHostRuntimePolicyResource(policy client.RuntimePolicy) string {
 		audit_user_account_management = true
 		audit_success_login = true
 	  }
+	  
+	  malware_scan_options {
+		enabled = true
+		action = "alert"
+		file_forensic_collection = true
+		include_directories = ["/tmp", "/var/log"]
+		exclude_processes = ["systemd"]
+	  }
+	  
 	  enable_ip_reputation = true
 	  enable_port_scan_protection     = true
 	  monitor_system_log_integrity     = true


### PR DESCRIPTION
### fix(runtime-policies): resolve default drift issues and add missing file_forensic_collection handling  

- **Defaults cleanup**:  
  - Removed `Default: true` from `enable_port_scan_protection` in container runtime policies.  
  - Removed `Default: true` from `enable_ip_reputation` in host runtime policies.  
  - These defaults caused unwanted Terraform plan drift when users didn’t explicitly set the fields, forcing workarounds.  
  - Now the fields properly default to `false/unset` when not specified, aligning with Terraform provider patterns and preventing drift.  
  - Fixes customer issue where policies showed unexpected changes in Terraform plans.  

- **File forensic collection fix**:  
  - Added missing `file_forensic_collection` field to host runtime policy expansion (`expandHostRuntimePolicy`).  
  - Extended test coverage for `malware_scan_options.file_forensic_collection` in both container and host runtime policy tests.  
  - Ensures consistent handling of `file_forensic_collection` during policy creation and updates.  