### PR TITLE
bug: Updated configuration of schedule_scan_settings attribute in aquasec_enforcer_group.

### DIFF
--- a/aquasec/data_enforcer_group.go
+++ b/aquasec/data_enforcer_group.go
@@ -451,7 +451,7 @@ func dataEnforcerGroupRead(ctx context.Context, d *schema.ResourceData, m interf
 		d.Set("token", group.Token)
 		d.Set("command", flattenCommands(group.Command))
 		d.Set("orchestrator", flattenOrchestrators(group.Orchestrator))
-		d.Set("schedule_scan_settings", flattenScheduleScanSettings(group.ScheduleScanSettings))
+		d.Set("schedule_scan_settings", flattenScheduleScanSetting(group.ScheduleScanSettings))
 		d.Set("type", group.Type)
 		d.Set("host_os", group.HostOs)
 		d.Set("install_command", group.InstallCommand)
@@ -516,19 +516,15 @@ func flattenOrchestrator(Orch client.EnforcerOrchestrator) map[string]interface{
 	}
 }
 
-func flattenScheduleScanSetting(setting client.EnforcerScheduleScanSettings) map[string]interface{} {
-	return map[string]interface{}{
-		"disabled":  setting.Disabled,
-		"is_custom": setting.IsCustom,
-		"days":      setting.Days,
-		"time":      setting.Time,
+func flattenScheduleScanSetting(setting client.EnforcerScheduleScanSettings) []interface{} {
+	return []interface{}{
+		map[string]interface{}{
+			"disabled":  setting.Disabled,
+			"is_custom": setting.IsCustom,
+			"days":      setting.Days,
+			"time":      setting.Time,
+		},
 	}
-}
-
-func flattenScheduleScanSettings(setting client.EnforcerScheduleScanSettings) []map[string]interface{} {
-	set := make([]map[string]interface{}, 1)
-	set[0] = flattenScheduleScanSetting(setting)
-	return set
 }
 
 func flattenCommands(Command client.EnforcerCommand) []map[string]interface{} {

--- a/aquasec/data_enforcer_group_test.go
+++ b/aquasec/data_enforcer_group_test.go
@@ -34,6 +34,14 @@ func TestAquasecEnforcerGroupDatasource(t *testing.T) {
 				Config: testAccCheckAquasecEnforcerGroupDataSource(basicEnforcerGroup),
 				Check:  testAccCheckAquasecEnforcerGroupDataSourceExists("data.aquasec_enforcer_groups.testegdata"),
 			},
+			{
+				Config: testAccCheckAquasecEnforcerGroupDataSourceWithScheduleScanSettings(basicEnforcerGroup),
+				Check:  testAccCheckAquasecEnforcerGroupDataSourceExists("data.aquasec_enforcer_groups.testegdata"),
+			},
+			{
+				Config: testAccCheckAquasecEnforcerGroupDataSource(basicEnforcerGroup),
+				Check:  testAccCheckAquasecEnforcerGroupDataSourceExists("data.aquasec_enforcer_groups.testegdata"),
+			},
 		},
 	})
 }
@@ -54,11 +62,48 @@ func testAccCheckAquasecEnforcerGroupDataSource(enforcerGroup client.EnforcerGro
 			namespace = "%s"
 			master = "%v"
 		}
+	}
+	data "aquasec_enforcer_groups" "testegdata" {
+		group_id = aquasec_enforcer_groups.testegdata.group_id
+		depends_on = [
+          aquasec_enforcer_groups.testegdata
+        ]
+	}
+	`,
+		enforcerGroup.ID,
+		enforcerGroup.Description,
+		enforcerGroup.LogicalName,
+		enforcerGroup.Enforce,
+		enforcerGroup.Gateways[0],
+		enforcerGroup.Type,
+		enforcerGroup.Orchestrator.Type,
+		enforcerGroup.Orchestrator.ServiceAccount,
+		enforcerGroup.Orchestrator.Namespace,
+		enforcerGroup.Orchestrator.Master,
+	)
+}
+
+func testAccCheckAquasecEnforcerGroupDataSourceWithScheduleScanSettings(enforcerGroup client.EnforcerGroup) string {
+	return fmt.Sprintf(`
+	
+	resource "aquasec_enforcer_groups" "testegdata" {
+		group_id = "%s"
+		description = "%s"
+		logical_name = "%s"
+		enforce = "%v"
+		gateways = ["%s"]
+		type = "%s"
+		orchestrator {
+			type = "%s"
+            service_account = "%s"
+			namespace = "%s"
+			master = "%v"
+		}
 		schedule_scan_settings {
-			disabled  = %v
-			is_custom = %v
-			days      = [0,1,2,3,4,5,6]
-			time      = [3, 0]
+			disabled  = false
+			is_custom = true
+			days      = [0,1,2,3,4]
+			time      = [6,0]
 		}
 	}
 	data "aquasec_enforcer_groups" "testegdata" {
@@ -78,9 +123,7 @@ func testAccCheckAquasecEnforcerGroupDataSource(enforcerGroup client.EnforcerGro
 		enforcerGroup.Orchestrator.ServiceAccount,
 		enforcerGroup.Orchestrator.Namespace,
 		enforcerGroup.Orchestrator.Master,
-		enforcerGroup.ScheduleScanSettings.Disabled,
-		enforcerGroup.ScheduleScanSettings.IsCustom)
-
+	)
 }
 
 func testAccCheckAquasecEnforcerGroupDataSourceExists(n string) resource.TestCheckFunc {

--- a/aquasec/resource_enforcer_group.go
+++ b/aquasec/resource_enforcer_group.go
@@ -378,19 +378,24 @@ func resourceEnforcerGroup() *schema.Resource {
 				Type:        schema.TypeList,
 				Description: "Scheduling scan time for which you are creating the Enforcer group.",
 				Optional:    true,
+				Computed:    true,
+				MaxItems:    1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"disabled": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"is_custom": {
 							Type:     schema.TypeBool,
 							Optional: true,
+							Computed: true,
 						},
 						"days": {
 							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeInt,
 							},
@@ -398,6 +403,7 @@ func resourceEnforcerGroup() *schema.Resource {
 						"time": {
 							Type:     schema.TypeList,
 							Optional: true,
+							Computed: true,
 							Elem: &schema.Schema{
 								Type: schema.TypeInt,
 							},
@@ -499,7 +505,7 @@ func resourceEnforcerGroupRead(ctx context.Context, d *schema.ResourceData, m in
 	d.Set("token", r.Token)
 	d.Set("command", flattenCommands(r.Command))
 	d.Set("orchestrator", flattenOrchestrators(r.Orchestrator))
-	d.Set("schedule_scan_settings", flattenScheduleScanSettings(r.ScheduleScanSettings))
+	d.Set("schedule_scan_settings", flattenScheduleScanSetting(r.ScheduleScanSettings))
 	d.Set("host_os", r.HostOs)
 	d.Set("install_command", r.InstallCommand)
 	d.Set("hosts_count", r.HostsCount)

--- a/aquasec/resource_enforcer_group_test.go
+++ b/aquasec/resource_enforcer_group_test.go
@@ -47,6 +47,28 @@ func TestAquasecEnforcerGroupResource(t *testing.T) {
 				),
 			},
 			{
+				Config: getBasicEnforcerGroupResourceWithScheduleScanSettings(basicEnforcerGroup),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rootRef, "group_id", basicEnforcerGroup.ID),
+					resource.TestCheckResourceAttr(rootRef, "description", basicEnforcerGroup.Description),
+					resource.TestCheckResourceAttr(rootRef, "logical_name", basicEnforcerGroup.LogicalName),
+					resource.TestCheckResourceAttr(rootRef, "enforce", fmt.Sprintf("%v", basicEnforcerGroup.Enforce)),
+					resource.TestCheckResourceAttr(rootRef, "gateways.0", basicEnforcerGroup.Gateways[0]),
+					resource.TestCheckResourceAttr(rootRef, "type", basicEnforcerGroup.Type),
+				),
+			},
+			{
+				Config: getBasicEnforcerGroupResource(basicEnforcerGroup),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(rootRef, "group_id", basicEnforcerGroup.ID),
+					resource.TestCheckResourceAttr(rootRef, "description", basicEnforcerGroup.Description),
+					resource.TestCheckResourceAttr(rootRef, "logical_name", basicEnforcerGroup.LogicalName),
+					resource.TestCheckResourceAttr(rootRef, "enforce", fmt.Sprintf("%v", basicEnforcerGroup.Enforce)),
+					resource.TestCheckResourceAttr(rootRef, "gateways.0", basicEnforcerGroup.Gateways[0]),
+					resource.TestCheckResourceAttr(rootRef, "type", basicEnforcerGroup.Type),
+				),
+			},
+			{
 				ResourceName:      fmt.Sprintf("aquasec_enforcer_groups.%s", basicEnforcerGroup.ID),
 				ImportState:       true,
 				ImportStateVerify: true,
@@ -70,11 +92,41 @@ func getBasicEnforcerGroupResource(enforcerGroup client.EnforcerGroup) string {
 			namespace = "%s"
 			master = "%v"
 		}
+	}
+	`, enforcerGroup.ID,
+		enforcerGroup.ID,
+		enforcerGroup.Description,
+		enforcerGroup.LogicalName,
+		enforcerGroup.Enforce,
+		enforcerGroup.Gateways[0],
+		enforcerGroup.Type,
+		enforcerGroup.Orchestrator.Type,
+		enforcerGroup.Orchestrator.ServiceAccount,
+		enforcerGroup.Orchestrator.Namespace,
+		enforcerGroup.Orchestrator.Master,
+	)
+}
+
+func getBasicEnforcerGroupResourceWithScheduleScanSettings(enforcerGroup client.EnforcerGroup) string {
+	return fmt.Sprintf(`
+	resource "aquasec_enforcer_groups" "%s" {
+		group_id = "%s"
+		description = "%s"
+		logical_name = "%s"
+		enforce = "%v"
+		gateways = ["%s"]
+		type = "%s"
+		orchestrator {
+			type = "%s"
+            service_account = "%s"
+			namespace = "%s"
+			master = "%v"
+		}
 		schedule_scan_settings {
-			disabled  = %v
-			is_custom = %v
-			days = [0,1,2,3,4,5,6]
-			time = [3,0]
+			disabled  = false
+			is_custom = true
+			days      = [0,1,2,3,4,5,6]
+			time      = [4,0]
 		}
 	}
 	`, enforcerGroup.ID,
@@ -88,8 +140,6 @@ func getBasicEnforcerGroupResource(enforcerGroup client.EnforcerGroup) string {
 		enforcerGroup.Orchestrator.ServiceAccount,
 		enforcerGroup.Orchestrator.Namespace,
 		enforcerGroup.Orchestrator.Master,
-		enforcerGroup.ScheduleScanSettings.Disabled,
-		enforcerGroup.ScheduleScanSettings.IsCustom,
 	)
 }
 


### PR DESCRIPTION
Implementation:
* Implemented the default values for days and time fields in the resource schema.
* Updated test cases to reflect the changes in the resource schema.
* Ensured backward compatibility by making the schedule_scan_settings attribute optional.