### PR TITLE
bug: TP |Drift Detection for aquasec_host_runtime_policy and aquasec_container_runtime_policy resources

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@
 # This ensures docker volumes are mounted from within provider directory instead.
 PROVIDER_DIR := $(abspath $(lastword $(dir $(MAKEFILE_LIST))))
 TEST         := "$(PROVIDER_DIR)/aquasec"
-HOSTNAME	 := github.com
+HOSTNAME	 := registry.terraform.io
 NAMESPACE	 := aquasec
 NAME 		 := aquasec
 BINARY		 := terraform-provider-${NAME}

--- a/aquasec/resource_container_runtime_policy.go
+++ b/aquasec/resource_container_runtime_policy.go
@@ -179,6 +179,7 @@ func resourceContainerRuntimePolicy() *schema.Resource {
 								Type: schema.TypeString,
 							},
 							Optional: true,
+							Computed: true,
 						},
 						"exclude_directories": {
 							Type:        schema.TypeList,

--- a/aquasec/resource_host_runtime_policy.go
+++ b/aquasec/resource_host_runtime_policy.go
@@ -457,6 +457,7 @@ func resourceHostRuntimePolicy() *schema.Resource {
 								Type: schema.TypeString,
 							},
 							Optional: true,
+							Computed: true,
 						},
 						"exclude_directories": {
 							Type:        schema.TypeList,


### PR DESCRIPTION
issue:
* The `include_directories` attribute in both `aquasec_host_runtime_policy` and `aquasec_container_runtime_policy` resources was not marked as `Computed`. This meant that if changes were made to this attribute outside of Terraform, Terraform would not detect these changes (drift) during subsequent runs.

Implementation:
* In the terraform schema for both resources, added `Computed: true` to the `include_directories` attribute. This allows Terraform to detect changes made outside of Terraform (drift) for this attribute.

fix:
* Added `Computed: true` to the `include_directories` attribute in both resources to enable drift detection.

jira:
SLK-102800: Terrafrom Provider | Drift Detection for aquasec_host_runtime_policy and aquasec_container_runtime_policy
