### PR TITLE
bug: tp | Unexpected Additional Prefix in ECR Registry Creation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -32,7 +32,7 @@ git clone https://github.com/aquasecurity/terraform-provider-aquasec.git
 
 cd terraform-provider-aquasec
 
-git checkout v0.10.0
+git checkout v0.10.1
 ```
 
 **Build and install the provider**

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ HOSTNAME	 := github.com
 NAMESPACE	 := aquasec
 NAME 		 := aquasec
 BINARY		 := terraform-provider-${NAME}
-VERSION      := 0.10.0
+VERSION      := 0.10.1
 OS_ARCH      := $(shell go env GOOS)_$(shell go env GOARCH)
 
 default: build

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To quickly get started using the Aquasec provider for Terraform, configure the p
 terraform {
   required_providers {
     aquasec = {
-      version = "0.10.0"
+      version = "0.10.1"
       source  = "aquasecurity/aquasec"
     }
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Use the navigation to the left to read about the available resources and data so
 terraform {
   required_providers {
     aquasec = {
-      version = "0.10.0"
+      version = "0.10.1"
       source  = "aquasecurity/aquasec"
     }
   }

--- a/examples/data-sources/main.tf
+++ b/examples/data-sources/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aquasec = {
-      //      version = "0.10.0"
+      //      version = "0.10.1"
       source = "aquasecurity/aquasec"
     }
   }

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aquasec = {
-      version = "0.10.0"
+      version = "0.10.1"
       source  = "aquasecurity/aquasec"
     }
   }

--- a/examples/resources/main.tf
+++ b/examples/resources/main.tf
@@ -1,7 +1,7 @@
 terraform {
   required_providers {
     aquasec = {
-      //version = "0.10.0"
+      //version = "0.10.1"
       source = "aquasecurity/aquasec"
     }
   }


### PR DESCRIPTION
issue:
* When creating a new ECR registry, an unexpected prefix is being added to the registry name. This prefix is not intended and causes issues with registry identification.

implementation:
* Investigate the code responsible for ECR registry creation.
* Identify where the prefix is being added.
* Remove or modify the code to prevent the addition of the unwanted prefix.

fix:
* Updated the ECR registry creation logic to ensure no additional prefix is added to the registry name.

jira:
* SLK-102794: Terraform Provider CSP | Terraform | Unexpected Additional Prefix in ECR Registry Creation