### PR TITLE
bug: fixed registry details in GNUmakefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -2,7 +2,7 @@
 # This ensures docker volumes are mounted from within provider directory instead.
 PROVIDER_DIR := $(abspath $(lastword $(dir $(MAKEFILE_LIST))))
 TEST         := "$(PROVIDER_DIR)/aquasec"
-HOSTNAME	 := registry.terraform.io
+HOSTNAME	 := github.com
 NAMESPACE	 := aquasec
 NAME 		 := aquasec
 BINARY		 := terraform-provider-${NAME}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches `HOSTNAME` in `GNUmakefile` from `registry.terraform.io` to `github.com`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f47f92204c2c71b8629576e68123abed3520eb35. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->