### PR TITLE
bug: fix missing assurance_type in examples for various policies

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -451,6 +451,7 @@ resource "aquasec_function_assurance_policy" "example_function_assurance_policy"
   //Required values
   application_scopes = ["Global"]
   name               = "example_function_assurance_policy"
+  assurance_type     = "function"
 
   //Values that default to true
   audit_on_failure = true
@@ -548,6 +549,7 @@ resource "aquasec_host_assurance_policy" "advanced" {
   name               = "host_policy_advanced"
   description        = "Advanced host assurance policy with key security controls"
   application_scopes = ["Global"]
+  assurance_type     = "host"
 
   # Policy enforcement
   enabled          = true
@@ -669,6 +671,7 @@ resource "aquasec_image" "example_aquasec_image" {
 resource "aquasec_image_assurance_policy" "test_image_policy" {
   name               = "test_image_assurance_policy"
   application_scopes = ["Global"]
+  assurance_type     = "image"
 
   block_failed     = true
   fail_cicd        = true
@@ -756,6 +759,7 @@ resource "aquasec_kubernetes_assurance_policy" "example_kubernetes_assurance_pol
   // Values that are required
   application_scopes = ["Global"]
   name               = "example_kubernetes_assurance_policy"
+  assurance_type     = "kubernetes"
 
   //Values that default to true
   audit_on_failure = true
@@ -938,6 +942,7 @@ resource "aquasec_user_saas" "IaC2" {
 resource "aquasec_vmware_assurance_policy" "example_vmware_assurance_policy" {
   application_scopes = ["Global"]
   name               = "example_vmware_assurance_policy"
+  assurance_type     = "cf_application"
 
   audit_on_failure = true
   block_failed     = true


### PR DESCRIPTION
implementation:
- Added the missing `assurance_type` attribute to the following resources in the examples:
  - `aquasec_function_assurance_policy`
  - `aquasec_host_assurance_policy`
  - `aquasec_image_assurance_policy`
  - `aquasec_kubernetes_assurance_policy`
  - `aquasec_cf_application_assurance_policy` 
- This ensures that the examples are complete and can be used as references for users implementing these policies.
- Fixing it for nighty_run test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add missing assurance_type fields to example assurance policies (function, host, image, kubernetes, cf_application) in examples/main.tf.
> 
> - **Examples**:
>   - **Assurance policies in** `examples/main.tf`:
>     - Add `assurance_type` to `aquasec_function_assurance_policy` ("function"), `aquasec_host_assurance_policy` ("host"), `aquasec_image_assurance_policy` ("image"), `aquasec_kubernetes_assurance_policy` ("kubernetes"), and `aquasec_vmware_assurance_policy` ("cf_application").
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aae8bad317d854bf95191338009db684f44cde4c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->