### PR TITLE
Correct default config path references

### DIFF
--- a/aquasec/provider.go
+++ b/aquasec/provider.go
@@ -80,7 +80,7 @@ func Provider(v string) *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("AQUA_CONFIG", "~/.aquasec/tf.config"),
-				Description: "This is the file path for Aqua provider configuration. The default configuration path is `~/.aqua/tf.config`. Can alternatively be sourced from the `AQUA_CONFIG` environment variable.",
+				Description: "This is the file path for Aqua provider configuration. The default configuration path is `~/.aquasec/tf.config`. Can alternatively be sourced from the `AQUA_CONFIG` environment variable.",
 			},
 			"validate": {
 				Type:        schema.TypeBool,

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ provider "aquasec" {
   verify_tls = false // Alternatively sourced from $AQUA_TLS_VERIFY
 
   // Alternatively, you can provide these configurations from a config file, and configure the provider as below
-  // config_path = '/path/to/tf.config' // defaults to '~/.aqua/tf.config' -- Alternatively sourced from $AQUA_CONFIG
+  // config_path = '/path/to/tf.config' // defaults to '~/.aquasec/tf.config' -- Alternatively sourced from $AQUA_CONFIG
   // validate = false // Skip provider credential validation
 
   //Alternatively, you can use API key authentication as below instead of username/password authentication.
@@ -58,7 +58,7 @@ provider "aquasec" {
 - `aqua_api_secret` (String, Sensitive) Shared secret for API key HMAC signing.
 - `aqua_url` (String) This is the base URL of your Aqua instance. Can alternatively be sourced from the `AQUA_URL` environment variable.
 - `ca_certificate_path` (String) This is the file path for server CA certificates if they are not available on the host OS. Can alternatively be sourced from the `AQUA_CA_CERT_PATH` environment variable.
-- `config_path` (String) This is the file path for Aqua provider configuration. The default configuration path is `~/.aqua/tf.config`. Can alternatively be sourced from the `AQUA_CONFIG` environment variable.
+- `config_path` (String) This is the file path for Aqua provider configuration. The default configuration path is `~/.aquasec/tf.config`. Can alternatively be sourced from the `AQUA_CONFIG` environment variable.
 - `csp_roles` (List of String)
 - `password` (String, Sensitive) This is the password that should be used to make the connection. Can alternatively be sourced from the `AQUA_PASSWORD` environment variable.
 - `username` (String, Sensitive) This is the user id that should be used to make the connection. Can alternatively be sourced from the `AQUA_USER` environment variable.

--- a/examples/provider/provider.tf
+++ b/examples/provider/provider.tf
@@ -16,7 +16,7 @@ provider "aquasec" {
   verify_tls = false // Alternatively sourced from $AQUA_TLS_VERIFY
 
   // Alternatively, you can provide these configurations from a config file, and configure the provider as below
-  // config_path = '/path/to/tf.config' // defaults to '~/.aqua/tf.config' -- Alternatively sourced from $AQUA_CONFIG
+  // config_path = '/path/to/tf.config' // defaults to '~/.aquasec/tf.config' -- Alternatively sourced from $AQUA_CONFIG
   // validate = false // Skip provider credential validation
 
   //Alternatively, you can use API key authentication as below instead of username/password authentication.


### PR DESCRIPTION
 Updates default config path references to `~/.aquasec/tf.config` in provider schema description, docs, and examples.
 
 - **Provider schema (`aquasec/provider.go`)**:
   - Aligns `config_path` description to reference `~/.aquasec/tf.config`.
 - **Docs (`docs/index.md`)**:
   - Updates example and schema text to use `~/.aquasec/tf.config`.
 - **Examples (`examples/provider/provider.tf`)**:
   - Updates commented `config_path` default to `~/.aquasec/tf.config`.
  
## Summary
- align the provider schema description with the actual default config file path
- update the docs and example configuration to mention `~/.aquasec/tf.config`
- regenerate the provider documentation

## Testing
- go generate ./...

