### PR TITLE
bug: SLK-99855 - Support more registry types in terraform provider

### DIFF
--- a/aquasec/data_registry.go
+++ b/aquasec/data_registry.go
@@ -24,9 +24,10 @@ func dataSourceRegistry() *schema.Resource {
 				Computed:    true,
 			},
 			"type": {
-				Type:        schema.TypeString,
-				Description: "Registry type (HUB / V1 / V2 / ACR / GAR / ENGINE / AWS / GCR).",
-				Computed:    true,
+				Type: schema.TypeString,
+				Description: "Registry type (HUB / V1 / V2 / ACR / GAR / AWS / GCR / ENGINE / CTRDENGINE / " +
+					"ART / NEXUS / QUAY / DTR / ATOMIC / OPENSHIFT / CF / HARBOR / ICR / PODMAN)",
+				Computed: true,
 			},
 			"name": {
 				Type:        schema.TypeString,

--- a/aquasec/resource_registry.go
+++ b/aquasec/resource_registry.go
@@ -52,9 +52,10 @@ func resourceRegistry() *schema.Resource {
 				Optional:    true,
 			},
 			"type": {
-				Type:        schema.TypeString,
-				Description: "Registry type (HUB / V1 / V2 / ACR / GAR / ENGINE / AWS / GCR).",
-				Required:    true,
+				Type: schema.TypeString,
+				Description: "Registry type (HUB / V1 / V2 / ACR / GAR / AWS / GCR / ENGINE / CTRDENGINE / " +
+					"ART / NEXUS / QUAY / DTR / ATOMIC / OPENSHIFT / CF / HARBOR / ICR / PODMAN)",
+				Required: true,
 			},
 			"username": {
 				Type:        schema.TypeString,

--- a/docs/data-sources/integration_registries.md
+++ b/docs/data-sources/integration_registries.md
@@ -68,7 +68,7 @@ description: |-
 - `password` (String) The password for registry authentication
 - `prefixes` (List of String) List of possible prefixes to image names pulled from the registry
 - `registries_type` (String) The type of registries
-- `type` (String) Registry type (HUB / V1 / V2 / ACR / GAR / ENGINE / AWS / GCR).
+- `type` (String) Registry type (HUB / V1 / V2 / ACR / GAR / AWS / GCR / ENGINE / CTRDENGINE / ART / NEXUS / QUAY / DTR / ATOMIC / OPENSHIFT / CF / HARBOR / ICR / PODMAN)
 - `url` (String) The URL, address or region of the registry
 - `username` (String) The username for registry authentication.
 

--- a/docs/resources/integration_registry.md
+++ b/docs/resources/integration_registry.md
@@ -91,7 +91,7 @@ resource "aquasec_integration_registry" "integration_registry" {
 ### Required
 
 - `name` (String) The name of the registry; string, required - this will be treated as the registry's ID, so choose a simple alphanumerical name without special signs and spaces
-- `type` (String) Registry type (HUB / V1 / V2 / ACR / GAR / ENGINE / AWS / GCR).
+- `type` (String) Registry type (HUB / V1 / V2 / ACR / GAR / AWS / GCR / ENGINE / CTRDENGINE / ART / NEXUS / QUAY / DTR / ATOMIC / OPENSHIFT / CF / HARBOR / ICR / PODMAN)
 
 ### Optional
 


### PR DESCRIPTION
Expands the type field’s supported registry types across schema and docs for integration registries.

**Provider Schema:**

- Update type field description to include additional registry types in aquasec/data_registry.go and aquasec/resource_registry.go (adds ENGINE, CTRDENGINE, ART, NEXUS, QUAY, DTR, ATOMIC, OPENSHIFT, CF, HARBOR, ICR, PODMAN).

**Docs:**

- Reflect expanded registry types in docs/data-sources/integration_registries.md and docs/resources/integration_registry.md.