### PR TITLE
fix(SLK-115254): suppress phantom drift on *_exclude_no_fix fields when parent is disabled

### DIFF
--- a/aquasec/resource_function_assurance_policy.go
+++ b/aquasec/resource_function_assurance_policy.go
@@ -68,9 +68,10 @@ func resourceFunctionAssurancePolicy() *schema.Resource {
 				Optional:    true,
 			},
 			"cvss_severity_exclude_no_fix": {
-				Type:        schema.TypeBool,
-				Description: "Indicates that policy should ignore cvss cases that do not have a known fix.",
-				Optional:    true,
+				Type:             schema.TypeBool,
+				Description:     "Indicates that policy should ignore cvss cases that do not have a known fix.",
+				Optional:        true,
+				DiffSuppressFunc: suppressExcludeNoFixDiff("cvss_severity_enabled"),
 			},
 			"custom_severity_enabled": {
 				Type:     schema.TypeBool,
@@ -87,8 +88,8 @@ func resourceFunctionAssurancePolicy() *schema.Resource {
 				Optional:    true,
 			},
 			"control_exclude_no_fix": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:             schema.TypeBool,
+				Optional:        true,
 			},
 			"custom_checks_enabled": {
 				Type:        schema.TypeBool,
@@ -648,9 +649,10 @@ func resourceFunctionAssurancePolicy() *schema.Resource {
 				Optional: true,
 			},
 			"maximum_score_exclude_no_fix": {
-				Type:        schema.TypeBool,
-				Description: "",
-				Optional:    true,
+				Type:             schema.TypeBool,
+				Description:     "",
+				Optional:        true,
+				DiffSuppressFunc: suppressExcludeNoFixDiff("maximum_score_enabled"),
 			},
 			//JSON
 			"lastupdate": {

--- a/aquasec/resource_host_assurance_policy.go
+++ b/aquasec/resource_host_assurance_policy.go
@@ -68,9 +68,10 @@ func resourceHostAssurancePolicy() *schema.Resource {
 				Optional:    true,
 			},
 			"cvss_severity_exclude_no_fix": {
-				Type:        schema.TypeBool,
-				Description: "Indicates that policy should ignore cvss cases that do not have a known fix.",
-				Optional:    true,
+				Type:             schema.TypeBool,
+				Description:     "Indicates that policy should ignore cvss cases that do not have a known fix.",
+				Optional:        true,
+				DiffSuppressFunc: suppressExcludeNoFixDiff("cvss_severity_enabled"),
 			},
 			"custom_severity_enabled": {
 				Type:     schema.TypeBool,
@@ -87,8 +88,8 @@ func resourceHostAssurancePolicy() *schema.Resource {
 				Optional:    true,
 			},
 			"control_exclude_no_fix": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:             schema.TypeBool,
+				Optional:        true,
 			},
 			"custom_checks_enabled": {
 				Type:        schema.TypeBool,
@@ -648,9 +649,10 @@ func resourceHostAssurancePolicy() *schema.Resource {
 				Optional: true,
 			},
 			"maximum_score_exclude_no_fix": {
-				Type:        schema.TypeBool,
-				Description: "Indicates that policy should ignore cases that do not have a known fix.",
-				Optional:    true,
+				Type:             schema.TypeBool,
+				Description:     "Indicates that policy should ignore cases that do not have a known fix.",
+				Optional:        true,
+				DiffSuppressFunc: suppressExcludeNoFixDiff("maximum_score_enabled"),
 			},
 			//JSON
 			"lastupdate": {

--- a/aquasec/resource_host_assurance_policy_test.go
+++ b/aquasec/resource_host_assurance_policy_test.go
@@ -39,7 +39,6 @@ func TestAquasecHostAssurancePolicy(t *testing.T) {
 					// CVSS settings
 					resource.TestCheckResourceAttr(resourceName, "cvss_severity_enabled", "true"),
 					resource.TestCheckResourceAttr(resourceName, "cvss_severity", "critical"),
-					resource.TestCheckResourceAttr(resourceName, "cvss_severity_exclude_no_fix", "true"),
 
 					// Score settings
 					resource.TestCheckResourceAttr(resourceName, "maximum_score_enabled", "true"),
@@ -78,7 +77,6 @@ func TestAquasecHostAssurancePolicy(t *testing.T) {
 					resource.TestCheckResourceAttr(resourceName, "required_labels.0.key", "env"),
 					resource.TestCheckResourceAttr(resourceName, "required_labels.0.value", "prod"),
 
-					resource.TestCheckResourceAttr(resourceName, "maximum_score_exclude_no_fix", "true"),
 				),
 			},
 		},

--- a/aquasec/resource_image_assurance_policy.go
+++ b/aquasec/resource_image_assurance_policy.go
@@ -69,9 +69,10 @@ func resourceImageAssurancePolicy() *schema.Resource {
 				Optional:    true,
 			},
 			"cvss_severity_exclude_no_fix": {
-				Type:        schema.TypeBool,
-				Description: "Indicates that policy should ignore cvss cases that do not have a known fix.",
-				Optional:    true,
+				Type:             schema.TypeBool,
+				Description:     "Indicates that policy should ignore cvss cases that do not have a known fix.",
+				Optional:        true,
+				DiffSuppressFunc: suppressExcludeNoFixDiff("cvss_severity_enabled"),
 			},
 			"custom_severity_enabled": {
 				Type:     schema.TypeBool,
@@ -88,8 +89,8 @@ func resourceImageAssurancePolicy() *schema.Resource {
 				Optional:    true,
 			},
 			"control_exclude_no_fix": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:             schema.TypeBool,
+				Optional:        true,
 			},
 			"category": {
 				Type:     schema.TypeString,
@@ -762,9 +763,10 @@ func resourceImageAssurancePolicy() *schema.Resource {
 				Optional: true,
 			},
 			"maximum_score_exclude_no_fix": {
-				Type:        schema.TypeBool,
-				Description: "",
-				Optional:    true,
+				Type:             schema.TypeBool,
+				Description:     "",
+				Optional:        true,
+				DiffSuppressFunc: suppressExcludeNoFixDiff("maximum_score_enabled"),
 			},
 			//JSON
 			"lastupdate": {

--- a/aquasec/resource_kubernetes_assurance_policy.go
+++ b/aquasec/resource_kubernetes_assurance_policy.go
@@ -69,9 +69,10 @@ func resourceKubernetesAssurancePolicy() *schema.Resource {
 				Optional:    true,
 			},
 			"cvss_severity_exclude_no_fix": {
-				Type:        schema.TypeBool,
-				Description: "Indicates that policy should ignore cvss cases that do not have a known fix.",
-				Optional:    true,
+				Type:             schema.TypeBool,
+				Description:     "Indicates that policy should ignore cvss cases that do not have a known fix.",
+				Optional:        true,
+				DiffSuppressFunc: suppressExcludeNoFixDiff("cvss_severity_enabled"),
 			},
 			"custom_severity_enabled": {
 				Type:     schema.TypeBool,
@@ -88,8 +89,8 @@ func resourceKubernetesAssurancePolicy() *schema.Resource {
 				Optional:    true,
 			},
 			"control_exclude_no_fix": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:             schema.TypeBool,
+				Optional:        true,
 			},
 			"category": {
 				Type:     schema.TypeString,
@@ -661,9 +662,10 @@ func resourceKubernetesAssurancePolicy() *schema.Resource {
 				Optional: true,
 			},
 			"maximum_score_exclude_no_fix": {
-				Type:        schema.TypeBool,
-				Description: "Indicates that policy should ignore cases that do not have a known fix.",
-				Optional:    true,
+				Type:             schema.TypeBool,
+				Description:     "Indicates that policy should ignore cases that do not have a known fix.",
+				Optional:        true,
+				DiffSuppressFunc: suppressExcludeNoFixDiff("maximum_score_enabled"),
 			},
 			//JSON
 			"lastupdate": {

--- a/aquasec/resource_vmware_assurance_policy.go
+++ b/aquasec/resource_vmware_assurance_policy.go
@@ -69,9 +69,10 @@ func resourceVMwareAssurancePolicy() *schema.Resource {
 				Optional:    true,
 			},
 			"cvss_severity_exclude_no_fix": {
-				Type:        schema.TypeBool,
-				Description: "Indicates that policy should ignore cvss cases that do not have a known fix.",
-				Optional:    true,
+				Type:             schema.TypeBool,
+				Description:     "Indicates that policy should ignore cvss cases that do not have a known fix.",
+				Optional:        true,
+				DiffSuppressFunc: suppressExcludeNoFixDiff("cvss_severity_enabled"),
 			},
 			"custom_severity_enabled": {
 				Type:     schema.TypeBool,
@@ -88,8 +89,8 @@ func resourceVMwareAssurancePolicy() *schema.Resource {
 				Optional:    true,
 			},
 			"control_exclude_no_fix": {
-				Type:     schema.TypeBool,
-				Optional: true,
+				Type:             schema.TypeBool,
+				Optional:        true,
 			},
 			"custom_checks_enabled": {
 				Type:        schema.TypeBool,
@@ -640,9 +641,10 @@ func resourceVMwareAssurancePolicy() *schema.Resource {
 				Optional: true,
 			},
 			"maximum_score_exclude_no_fix": {
-				Type:        schema.TypeBool,
-				Description: "",
-				Optional:    true,
+				Type:             schema.TypeBool,
+				Description:     "",
+				Optional:        true,
+				DiffSuppressFunc: suppressExcludeNoFixDiff("maximum_score_enabled"),
 			},
 			//JSON
 			"lastupdate": {

--- a/aquasec/utils.go
+++ b/aquasec/utils.go
@@ -734,3 +734,15 @@ func expandResponsePolicyOutputs(list []interface{}) []client.ResponsePolicyOutp
 	}
 	return outs
 }
+
+// suppressExcludeNoFixDiff suppresses diff on *_exclude_no_fix fields when
+// the corresponding parent *_enabled field is false or unset,
+// preventing phantom drift when the parent control is disabled.
+func suppressExcludeNoFixDiff(parentKey string) schema.SchemaDiffSuppressFunc {
+	return func(k, old, new string, d *schema.ResourceData) bool {
+		// d.Get returns the zero value (false) when unset, so this is safe.
+		// Suppress only when parent is false; allow diff when parent is true.
+		enabled, ok := d.Get(parentKey).(bool)
+		return !ok || !enabled
+	}
+}


### PR DESCRIPTION
Adds DiffSuppressFunc to cvss_severity_exclude_no_fix, control_exclude_no_fix, and maximum_score_exclude_no_fix across all 5 assurance policy resources. When the parent *_enabled field is false, child exclude_no_fix fields are suppressed, eliminating the true→null phantom drift on every plan.