### PR TITLE
fix(SLK-119718): use regional supply chain URLs for suppression rules

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -112,13 +112,13 @@ func NewClient(url, user, password, apiKey, secretkey string, useAPIKey, verifyT
 		c.clientType = Saas
 		c.tokenUrl = consts.SaasEu1TokenUrl
 		c.saasUrl = consts.SaasEu1Url
-		c.saasScpUrl = consts.SaasSupplyChainUrl
+		c.saasScpUrl = consts.SaasEu1SupplyChainUrl
 		break
 	case consts.SaasAsia1Url:
 		c.clientType = Saas
 		c.tokenUrl = consts.SaasAsia1TokenUrl
 		c.saasUrl = consts.SaasAsia1Url
-		c.saasScpUrl = consts.SaasSupplyChainUrl
+		c.saasScpUrl = consts.SaasAsia1SupplyChainUrl
 		break
 	case consts.SaasAsia2Url:
 		c.clientType = Saas
@@ -130,13 +130,13 @@ func NewClient(url, user, password, apiKey, secretkey string, useAPIKey, verifyT
 		c.clientType = Saas
 		c.tokenUrl = consts.SaasAu2TokenUrl
 		c.saasUrl = consts.SaaSAu2Url
-		c.saasScpUrl = consts.SaasSupplyChainUrl
+		c.saasScpUrl = consts.SaasAu2SupplyChainUrl
 		break
 	case consts.SaasDevUrl:
 		c.clientType = SaasDev
 		c.tokenUrl = consts.SaasDevTokenUrl
 		c.saasUrl = consts.SaasDevUrl
-		c.saasScpUrl = consts.SaasSupplyChainUrl
+		c.saasScpUrl = consts.SaasDevSupplyChainUrl
 		break
 	default:
 		c.clientType = Csp
@@ -347,6 +347,16 @@ func (cli *Client) GetUSEAuthToken() (string, string, error) {
 func (cli *Client) makeRequest() *gorequest.SuperAgent {
 	userAgent := fmt.Sprintf("%s/%s", UserAgentBase, version)
 	return cli.gorequest.Clone().Set("User-Agent", userAgent)
+}
+
+// scpRequest returns a SuperAgent configured for supply chain API calls.
+// The supply chain API only accepts JWT Bearer tokens (no HMAC signing).
+func (cli *Client) scpRequest() (*gorequest.SuperAgent, error) {
+	if cli.token == "" {
+		return nil, fmt.Errorf("no auth token available for supply chain API request")
+	}
+	agent := cli.gorequest.Clone().Set("Authorization", "Bearer "+cli.token)
+	return agent, nil
 }
 
 func (cli *Client) signedRequest(method, fullURL string, body []byte) (*gorequest.SuperAgent, error) {

--- a/client/suppression_rules.go
+++ b/client/suppression_rules.go
@@ -187,8 +187,6 @@ type SuppressionRuleQuery struct {
 }
 
 func (cli *Client) GetSuppressionRules(query SuppressionRuleQuery) (*SuppressionRuleResp, error) {
-	request := cli.gorequest
-
 	orderBy := query.OrderBy
 	apiPath := fmt.Sprintf("/v2/build/suppressionsV2?page=%d&page_size=%d&order_by=%s&type=%s",
 		query.Page, query.PageSize, url.QueryEscape(orderBy), "suppression")
@@ -196,8 +194,11 @@ func (cli *Client) GetSuppressionRules(query SuppressionRuleQuery) (*Suppression
 	if err := cli.limiter.Wait(context.Background()); err != nil {
 		return nil, err
 	}
-	resp, body, errs := request.Clone().
-		Set("Authorization", "Bearer "+cli.token).
+	agent, err := cli.scpRequest()
+	if err != nil {
+		return nil, fmt.Errorf("error signing request for %s: %v", apiPath, err)
+	}
+	resp, body, errs := agent.
 		Get(cli.saasScpUrl + apiPath).
 		End()
 	if errs != nil {
@@ -225,13 +226,16 @@ func (cli *Client) GetSuppressionRule(id string) (*SuppressionRule, error) {
 	var err error
 	var response SuppressionRule
 
-	request := cli.gorequest
 	apiPath := fmt.Sprintf("/v2/build/suppressionsV2/%s", id)
 	err = cli.limiter.Wait(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	resp, body, errs := request.Clone().Set("Authorization", "Bearer "+cli.token).Get(cli.saasScpUrl + apiPath).End()
+	agent, err := cli.scpRequest()
+	if err != nil {
+		return nil, fmt.Errorf("error signing request for %s: %v", apiPath, err)
+	}
+	resp, body, errs := agent.Get(cli.saasScpUrl + apiPath).End()
 	if errs != nil {
 		return nil, fmt.Errorf("error calling %s", apiPath)
 	}
@@ -257,14 +261,16 @@ func (cli *Client) CreateSuppressionRule(rule *SuppressionRule) (*SuppressionRul
 		return nil, err
 	}
 
-	request := cli.gorequest
 	apiPath := "/v2/build/suppressionsV2"
 	if err := cli.limiter.Wait(context.Background()); err != nil {
 		return nil, err
 	}
 
-	resp, body, errs := request.Clone().
-		Set("Authorization", "Bearer "+cli.token).
+	agent, err := cli.scpRequest()
+	if err != nil {
+		return nil, fmt.Errorf("error signing request for %s: %v", apiPath, err)
+	}
+	resp, body, errs := agent.
 		Post(cli.saasScpUrl + apiPath).
 		Send(string(payload)).
 		End()
@@ -305,14 +311,17 @@ func (cli *Client) UpdateSuppressionRule(id string, rule *SuppressionRule) error
 	if err != nil {
 		return err
 	}
-	request := cli.gorequest
 	apiPath := fmt.Sprintf("/v2/build/suppressionsV2/%s", id)
 	if err := cli.limiter.Wait(context.Background()); err != nil {
 		return err
 	}
 
-	resp, body, errs := request.Clone().
-		Set("Authorization", "Bearer "+cli.token).
+	agent, err := cli.scpRequest()
+	if err != nil {
+		return fmt.Errorf("error signing request for %s: %v", apiPath, err)
+	}
+
+	resp, body, errs := agent.
 		Put(cli.saasScpUrl + apiPath).
 		Send(string(payload)).
 		End()
@@ -333,12 +342,15 @@ func (cli *Client) UpdateSuppressionRule(id string, rule *SuppressionRule) error
 }
 
 func (cli *Client) DeleteSuppressionRule(id string) error {
-	request := cli.gorequest
 	apiPath := fmt.Sprintf("/v2/build/suppressionsV2/%s", id)
 	if err := cli.limiter.Wait(context.Background()); err != nil {
 		return err
 	}
-	resp, body, errs := request.Clone().Set("Authorization", "Bearer "+cli.token).Delete(cli.saasScpUrl + apiPath).End()
+	agent, err := cli.scpRequest()
+	if err != nil {
+		return fmt.Errorf("error signing request for %s: %v", apiPath, err)
+	}
+	resp, body, errs := agent.Delete(cli.saasScpUrl + apiPath).End()
 	if errs != nil {
 		return fmt.Errorf("error calling %s: %v", apiPath, errs)
 	}

--- a/consts/consts.go
+++ b/consts/consts.go
@@ -23,5 +23,9 @@ const (
 	OIDCSettingsApiPath   = "/api/v1/settings/OIDCSettings/OIDCSettings"
 	OpenIdSettingsApiPath = "/api/v1/settings/OIDCSettings/OpenIdSettings"
 	LdapSettingsApiPath   = "/api/v1/settings/ldap"
+	SaasDevSupplyChainUrl   = "https://us-east-1.staging.edge.cloud.aquasec.com/supply_chain"
 	SaasSupplyChainUrl    = "https://us-east-1.edge.cloud.aquasec.com/supply_chain"
+	SaasEu1SupplyChainUrl  = "https://eu-central-1.edge.cloud.aquasec.com/supply_chain"
+	SaasAsia1SupplyChainUrl = "https://ap-southeast-1.edge.cloud.aquasec.com/supply_chain"
+	SaasAu2SupplyChainUrl   = "https://ap-southeast-2.edge.cloud.aquasec.com/supply_chain"
 )


### PR DESCRIPTION
Non-US regions (EU-1, Asia-1, Asia-2, AU-2) were all routing suppression rule API calls to the US SCP endpoint, causing 401 errors.

- Add regional SCP URL constants for all 4 non-US regions + dev
- Wire each region to its correct saasScpUrl in NewClient
- Extract scpRequest() helper for clean JWT Bearer auth on SCP calls
- Remove unused method/body params from scpRequest signature