### PR TITLE
ci(test): cap `GITHUB_TOKEN` to `contents: read`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,9 @@ on:
   # change.
   # schedule:
   #   - cron: '0 13 * * *'
+permissions:
+  contents: read
+
 jobs:
   build:
     if: contains(github.event.pull_request.labels.*.name, 'safe_to_test')


### PR DESCRIPTION
The `test` workflow runs the terraform-provider acceptance tests. No GitHub API writes from the workflow, so a workflow-level `contents: read` is the right cap for the default `GITHUB_TOKEN`.

Same post-CVE-2025-30066 (`tj-actions/changed-files`) hardening pattern. YAML validated locally.