### PR TITLE
fix(application_scope): use CSP URL for SaaS scope CRUD

### DIFF
--- a/client/application_scope.go
+++ b/client/application_scope.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"log"
 
 	"github.com/pkg/errors"
@@ -26,9 +25,9 @@ type Category struct {
 }
 
 type Artifact struct {
-	Image    CommonStruct `json:"image"`
-	Function CommonStruct `json:"function"`
-	CF       CommonStruct `json:"cf"`
+	Image     CommonStruct `json:"image"`
+	Function  CommonStruct `json:"function"`
+	CF        CommonStruct `json:"cf"`
 	CodeBuild CommonStruct `json:"codebuild"`
 }
 
@@ -58,41 +57,30 @@ type Variables struct {
 func (cli *Client) GetApplicationScope(name string) (*ApplicationScope, error) {
 	var err error
 	var response ApplicationScope
-	var baseUrl = cli.url
 
 	cli.gorequest.Set("Authorization", "Bearer "+cli.token)
 	apiPath := fmt.Sprintf("/api/v2/access_management/scopes/%s", name)
-
-	if cli.clientType == Saas || cli.clientType == SaasDev {
-		baseUrl = cli.saasUrl + "/api"
-		apiPath = fmt.Sprintf("/access_mgmt/scopes/%s", name)
-	}
 
 	err = cli.limiter.Wait(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	resp, body, errs := cli.gorequest.Clone().Get(baseUrl + apiPath).End()
+	resp, body, errs := cli.gorequest.Clone().Get(cli.url + apiPath).End()
 	if errs != nil {
 		return nil, errors.Wrap(getMergedError(errs), "failed getting Application Scopes")
 	}
 	if resp.StatusCode == 200 {
 		err = json.Unmarshal([]byte(body), &response)
 		if err != nil {
-			log.Printf("Error calling func GetApplicationScope from %s%s, %v ", baseUrl, apiPath, err)
+			log.Printf("Error calling func GetApplicationScope from %s%s, %v ", cli.url, apiPath, err)
 			return nil, err
 		}
 	} else {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Printf("Failed to read response Body")
-			return nil, err
-		}
 		var errorResponse ErrorResponse
-		err = json.Unmarshal(body, &errorResponse)
+		err = json.Unmarshal([]byte(body), &errorResponse)
 		if err != nil {
-			log.Printf("Failed to Unmarshal response Body to ErrorResponse. Body: %v. error: %v", string(body), err)
-			return nil, err
+			log.Printf("Failed to Unmarshal response Body to ErrorResponse. Body: %v. error: %v", body, err)
+			return nil, fmt.Errorf("failed getting Application Scope. status: %v. response: %v", resp.Status, body)
 		}
 		return nil, fmt.Errorf("failed getting Application Scope. status: %v. error message: %v", resp.Status, errorResponse.Message)
 	}
@@ -104,14 +92,8 @@ func (cli *Client) GetApplicationScope(name string) (*ApplicationScope, error) {
 
 // CreateApplicationScope - creates single Aqua Application Scope
 func (cli *Client) CreateApplicationScope(applicationscope *ApplicationScope) error {
-	baseUrl := cli.url
-	apiPath := fmt.Sprintf("/api/v2/access_management/scopes")
+	apiPath := "/api/v2/access_management/scopes"
 	request := cli.gorequest
-
-	if cli.clientType == Saas || cli.clientType == SaasDev {
-		baseUrl = cli.saasUrl + "/api"
-		apiPath = "/access_mgmt/scopes"
-	}
 
 	payload, err := json.Marshal(applicationscope)
 	if err != nil {
@@ -122,21 +104,16 @@ func (cli *Client) CreateApplicationScope(applicationscope *ApplicationScope) er
 	if err != nil {
 		return err
 	}
-	resp, _, errs := request.Clone().Set("Authorization", "Bearer "+cli.token).Post(baseUrl + apiPath).Send(string(payload)).End()
+	resp, body, errs := request.Clone().Set("Authorization", "Bearer "+cli.token).Post(cli.url + apiPath).Send(string(payload)).End()
 	if errs != nil {
 		return errors.Wrap(getMergedError(errs), "failed creating Application Scope.")
 	}
 	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Printf("Failed to read response Body")
-			return err
-		}
 		var errorResponse ErrorResponse
-		err = json.Unmarshal(body, &errorResponse)
+		err = json.Unmarshal([]byte(body), &errorResponse)
 		if err != nil {
-			log.Printf("Failed to Unmarshal response Body to ErrorResponse. Body: %v. error: %v", string(body), err)
-			return err
+			log.Printf("Failed to Unmarshal response Body to ErrorResponse. Body: %v. error: %v", body, err)
+			return fmt.Errorf("failed creating Application Scope. status: %v. response: %v", resp.Status, body)
 		}
 		return fmt.Errorf("failed creating Application Scope. status: %v. error message: %v", resp.Status, errorResponse.Message)
 	}
@@ -149,34 +126,23 @@ func (cli *Client) UpdateApplicationScope(applicationscope *ApplicationScope, na
 	if err != nil {
 		return err
 	}
-	baseUrl := cli.url
 	request := cli.gorequest
 	apiPath := fmt.Sprintf("/api/v2/access_management/scopes/%s", name)
-
-	if cli.clientType == Saas || cli.clientType == SaasDev {
-		baseUrl = cli.saasUrl + "/api"
-		apiPath = "/access_mgmt/scopes"
-	}
 
 	err = cli.limiter.Wait(context.Background())
 	if err != nil {
 		return err
 	}
-	resp, _, errs := request.Clone().Set("Authorization", "Bearer "+cli.token).Put(baseUrl + apiPath).Send(string(payload)).End()
+	resp, body, errs := request.Clone().Set("Authorization", "Bearer "+cli.token).Put(cli.url + apiPath).Send(string(payload)).End()
 	if errs != nil {
 		return errors.Wrap(getMergedError(errs), "failed modifying Application Scope")
 	}
-	if resp.StatusCode != 201 && resp.StatusCode != 204 {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Printf("Failed to read response Body")
-			return err
-		}
+	if resp.StatusCode != 201 && resp.StatusCode != 204 && resp.StatusCode != 200 {
 		var errorResponse ErrorResponse
-		err = json.Unmarshal(body, &errorResponse)
+		err = json.Unmarshal([]byte(body), &errorResponse)
 		if err != nil {
-			log.Printf("Failed to Unmarshal response Body to ErrorResponse. Body: %v. error: %v", string(body), err)
-			return err
+			log.Printf("Failed to Unmarshal response Body to ErrorResponse. Body: %v. error: %v", body, err)
+			return fmt.Errorf("failed modifying Application Scope. status: %v. response: %v", resp.Status, body)
 		}
 		return fmt.Errorf("failed modifying Application Scope. status: %v. error message: %v", resp.Status, errorResponse.Message)
 	}
@@ -187,32 +153,21 @@ func (cli *Client) UpdateApplicationScope(applicationscope *ApplicationScope, na
 func (cli *Client) DeleteApplicationScope(name string) error {
 	request := cli.gorequest
 	apiPath := fmt.Sprintf("/api/v2/access_management/scopes/%s", name)
-	baseUrl := cli.url
-
-	if cli.clientType == Saas || cli.clientType == SaasDev {
-		baseUrl = cli.saasUrl + "/api"
-		apiPath = fmt.Sprintf("/access_mgmt/scopes/%s", name)
-	}
 
 	err := cli.limiter.Wait(context.Background())
 	if err != nil {
 		return err
 	}
-	resp, _, errs := request.Clone().Set("Authorization", "Bearer "+cli.token).Delete(baseUrl + apiPath).End()
+	resp, body, errs := request.Clone().Set("Authorization", "Bearer "+cli.token).Delete(cli.url + apiPath).End()
 	if errs != nil {
 		return errors.Wrap(getMergedError(errs), "failed deleting Application Scope")
 	}
-	if resp.StatusCode != 204 {
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			log.Printf("Failed to read response Body")
-			return err
-		}
+	if resp.StatusCode != 204 && resp.StatusCode != 200 {
 		var errorResponse ErrorResponse
-		err = json.Unmarshal(body, &errorResponse)
+		err = json.Unmarshal([]byte(body), &errorResponse)
 		if err != nil {
-			log.Printf("Failed to Unmarshal response Body to ErrorResponse. Body: %v. error: %v", string(body), err)
-			return err
+			log.Printf("Failed to Unmarshal response Body to ErrorResponse. Body: %v. error: %v", body, err)
+			return fmt.Errorf("failed deleting Application Scope. status: %v. response: %v", resp.Status, body)
 		}
 		return fmt.Errorf("failed deleting Application Scope, status: %v. error message: %v", resp.Status, errorResponse.Message)
 	}


### PR DESCRIPTION
## Summary

Fixes `aquasec_application_scope_saas` resource failing with "unexpected end of JSON input" on all CRUD operations.

## Root Cause

The SaaS code path routed scope API calls to `cli.saasUrl/api/access_mgmt/scopes` (platform RBAC service) which returns errors for individual scope operations. The actual error was masked because gorequest response body was discarded (`resp, _, errs :=`) before error parsing, causing `json.Unmarshal` on empty bytes.

## Changes

- Remove SaaS URL branching; use `cli.url` (auto-resolved CSP URL) with `/api/v2/access_management/scopes` for all client types
- Capture gorequest body string instead of discarding with `_`
- Use captured body for error response parsing (fixes opaque error messages)
- Fix Update SaaS path that was missing scope name in URL
- Accept HTTP 200 in Update/Delete success status codes

## Testing

- `go build ./...` ✅
- `go vet ./...` ✅
- `TF_ACC=1` acceptance tests pass on dev ✅
- `TF_ACC=1` acceptance tests pass on prod ✅
- Manual curl validation of POST/GET/DELETE via CSP URL ✅

## Notes

- No user-facing config change required — `cli.url` is auto-resolved during auth via the provisioning service
- The `aquasec_application_scope` (non-SaaS) resource is unaffected

Resolves: SLK-128566

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes SaaS API routing and success/status handling for access-management scopes; behavior is intentional but affects a security-sensitive Terraform resource path.
> 
> **Overview**
> Fixes SaaS application scope Terraform operations that failed with opaque **"unexpected end of JSON input"** errors by correcting where requests go and how failures are read.
> 
> **Routing:** Removes `Saas` / `SaasDev` branches that hit `cli.saasUrl` + `/access_mgmt/scopes`. **Get, create, update, and delete** now all use **`cli.url`** with **`/api/v2/access_management/scopes`** (including the scope name on update/delete). This also fixes the SaaS **update** path that previously omitted the scope name in the URL.
> 
> **Errors:** CRUD calls no longer discard the gorequest **`body`** string; error responses are unmarshaled from that body instead of re-reading an empty `resp.Body`, with clearer fallbacks when JSON parsing fails.
> 
> **Success codes:** **Update** and **delete** treat **HTTP 200** as success in addition to 201/204.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dd14dead0881df413098b8f2bcad5e8b1b38dd7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->