### PR TITLE
fix: SLK-128566 | application_scope: use v2 API endpoint for all client types

### DIFF
--- a/client/application_scope_test.go
+++ b/client/application_scope_test.go
@@ -1,0 +1,104 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/parnurzeal/gorequest"
+	"golang.org/x/time/rate"
+)
+
+// TestSLK128566_SaasClientUsesV2Endpoint verifies that SaaS and CSP clients both use
+// /api/v2/access_management/scopes/ and NOT the legacy /api/access_mgmt/scopes/ path.
+func TestSLK128566_SaasClientUsesV2Endpoint(t *testing.T) {
+	scope := ApplicationScope{Name: "test-scope", Description: "test"}
+	scopeJSON, _ := json.Marshal(scope)
+
+	tests := []struct {
+		name       string
+		clientType string
+	}{
+		{"CSP client uses v2 endpoint", Csp},
+		{"SaaS client uses v2 endpoint", Saas},
+		{"SaasDev client uses v2 endpoint", SaasDev},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Path
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusOK)
+				w.Write(scopeJSON)
+			}))
+			defer srv.Close()
+
+			cli := &Client{
+				url:        srv.URL,
+				clientType: tt.clientType,
+				saasUrl:    srv.URL,
+				gorequest:  gorequest.New(),
+				limiter:    rate.NewLimiter(10, 3),
+			}
+
+			_, err := cli.GetApplicationScope("test-scope")
+			if err != nil {
+				t.Fatalf("GetApplicationScope returned unexpected error: %v", err)
+			}
+
+			const wantPath = "/api/v2/access_management/scopes/test-scope"
+			const legacyPath = "/api/access_mgmt/scopes/test-scope"
+
+			if capturedPath != wantPath {
+				t.Errorf("expected path %q, got %q", wantPath, capturedPath)
+			}
+			if capturedPath == legacyPath {
+				t.Errorf("used legacy SaaS path %q — regression of SLK-128566", legacyPath)
+			}
+		})
+	}
+}
+
+// TestSLK128566_CreateUsesV2Endpoint verifies Create uses the v2 endpoint for all client types.
+func TestSLK128566_CreateUsesV2Endpoint(t *testing.T) {
+	tests := []struct {
+		name       string
+		clientType string
+	}{
+		{"CSP", Csp},
+		{"SaaS", Saas},
+		{"SaasDev", SaasDev},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var capturedPath string
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				capturedPath = r.URL.Path
+				w.WriteHeader(http.StatusCreated)
+			}))
+			defer srv.Close()
+
+			cli := &Client{
+				url:        srv.URL,
+				clientType: tt.clientType,
+				saasUrl:    srv.URL,
+				gorequest:  gorequest.New(),
+				limiter:    rate.NewLimiter(10, 3),
+			}
+
+			err := cli.CreateApplicationScope(&ApplicationScope{Name: "scope1"})
+			if err != nil {
+				t.Fatalf("CreateApplicationScope returned unexpected error: %v", err)
+			}
+
+			const wantPath = "/api/v2/access_management/scopes"
+			if capturedPath != wantPath {
+				t.Errorf("expected path %q, got %q", wantPath, capturedPath)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Issue

SaaS customers get 'unexpected end of JSON input' when creating/reading/updating/deleting application scopes via Terraform. Started around May 12 2026 when the SaaS platform retired the legacy endpoint.

## Root Cause

The `GetApplicationScope`, `CreateApplicationScope`, `UpdateApplicationScope`, and `DeleteApplicationScope` functions contained a SaaS-specific branch that rewrote the API path from `/api/v2/access_management/scopes/` to `/api/access_mgmt/scopes/` and switched the base URL to `cli.saasUrl`. That legacy endpoint no longer exists on SaaS, returning a 404 with an empty body — which causes the JSON unmarshal to fail with 'unexpected end of JSON input'.

The v2 endpoint (`/api/v2/access_management/scopes/`) works correctly for both CSP and SaaS environments.

## Solution

Removed the SaaS/SaasDev URL-rewriting block from all four CRUD functions. All client types now uniformly call `cli.url + /api/v2/access_management/scopes/`.

## Files Changed

| File | Change |
|------|--------|
| `client/application_scope.go` | Remove legacy SaaS path override in Get/Create/Update/Delete |
| `client/application_scope_test.go` | Unit tests verifying v2 endpoint is used for CSP, SaaS, and SaasDev |

## Testing

Unit tests confirm the correct endpoint is called for all three client types (CSP, SaaS, SaasDev):

```
--- PASS: TestSLK128566_SaasClientUsesV2Endpoint/CSP_client_uses_v2_endpoint
--- PASS: TestSLK128566_SaasClientUsesV2Endpoint/SaaS_client_uses_v2_endpoint
--- PASS: TestSLK128566_SaasClientUsesV2Endpoint/SaasDev_client_uses_v2_endpoint
--- PASS: TestSLK128566_CreateUsesV2Endpoint/CSP
--- PASS: TestSLK128566_CreateUsesV2Endpoint/SaaS
--- PASS: TestSLK128566_CreateUsesV2Endpoint/SaasDev
```

Resolves: SLK-128566

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes which API base URL and path SaaS/SaasDev use for scope CRUD; behavior is intentional but affects all Terraform scope operations on SaaS.
> 
> **Overview**
> Fixes SaaS Terraform failures (`unexpected end of JSON input`) by stopping use of the retired `/api/access_mgmt/scopes/` path and **`cli.saasUrl`** rewrite for SaaS/SaasDev in application scope **Get/Create/Update/Delete**—all client types now call **`/api/v2/access_management/scopes/`** on **`cli.url`**.
> 
> This PR adds **`client/application_scope_test.go`** with httptest coverage so CSP, SaaS, and SaasDev hit the v2 paths for **Get** and **Create**, and explicitly fail if the legacy path is used again (SLK-128566).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649849da614628a50a034ec56524e8bac009b205. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->