### PR TITLE
release: v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.15.1 (June 24, 2026)
+
+BUG FIXES:
+
+* `aquasec_application_scope_saas`: Fix "unexpected end of JSON input" error on all CRUD operations. The SaaS code path was routing to an incorrect API endpoint. Now uses the auto-resolved CSP URL with the correct `/api/v2/access_management/scopes` path. No user configuration change required. ([#388](https://github.com/aquasecurity/terraform-provider-aquasec/pull/388))
+
 ## 0.1.0 (Unreleased)
 
 BACKWARDS INCOMPATIBILITIES / NOTES:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ HOSTNAME	 := github.com
 NAMESPACE	 := aquasec
 NAME 		 := aquasec
 BINARY		 := terraform-provider-${NAME}
-VERSION      := 0.15.0
+VERSION      := 0.15.1
 OS_ARCH      := $(shell go env GOOS)_$(shell go env GOARCH)
 
 default: build

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To quickly get started using the Aquasec provider for Terraform, configure the p
 terraform {
   required_providers {
     aquasec = {
-      version = "0.15.0"
+      version = "0.15.1"
       source  = "aquasecurity/aquasec"
     }
   }

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ Use the navigation to the left to read about the available resources and data so
 terraform {
   required_providers {
     aquasec = {
-      version = "0.15.0"
+      version = "0.15.1"
       source  = "aquasecurity/aquasec"
     }
   }


### PR DESCRIPTION
## Summary

Bug fix release for `aquasec_application_scope_saas` CRUD failures.

## Changes

- Bump version to 0.15.1 in GNUmakefile, docs/index.md, README.md
- Add CHANGELOG.md entry for 0.15.1

## What was fixed

`aquasec_application_scope_saas`: Fix "unexpected end of JSON input" error on all CRUD operations. The SaaS code path was routing to an incorrect API endpoint. Now uses the auto-resolved CSP URL with the correct `/api/v2/access_management/scopes` path.

## Post-merge

After merge, tag `v0.15.1` on the merge commit to trigger GoReleaser via GitHub Actions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No runtime code changes in this diff—only version metadata and documentation for a patch release.
> 
> **Overview**
> **Release v0.15.1** — packaging only; the functional fix landed in [#388](https://github.com/aquasecurity/terraform-provider-aquasec/pull/388).
> 
> This PR updates the build version in `GNUmakefile` (including linker `-X` version strings), bumps the example `required_providers` pin from **0.15.0** to **0.15.1** in `README.md` and `docs/index.md`, and adds a **0.15.1** `CHANGELOG.md` entry describing the bug fix: `aquasec_application_scope_saas` CRUD was failing with "unexpected end of JSON input" because the SaaS path hit the wrong API URL; it now uses the auto-resolved CSP base with `/api/v2/access_management/scopes`, with no provider config changes required.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e6d186008e1bf748443ac7f055723a3ca87b39cb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->